### PR TITLE
Feature/stream session frame stream

### DIFF
--- a/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/FrameProcessor.kt
+++ b/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/FrameProcessor.kt
@@ -5,6 +5,7 @@ import android.graphics.Canvas
 import android.util.Log
 import android.view.Surface
 import com.meta.wearable.dat.camera.types.VideoFrame
+import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 
 /**
@@ -75,9 +76,9 @@ internal class FrameProcessor {
         if (frameCount % 30 == 0 && lastTime != null) {
             val actualFPS = 1_000_000_000.0 / (now - lastTime)
             Log.d(
-                    TAG,
-                    "Texture path — $frameCount frames, " +
-                            "target: $targetFPS, actual: ${"%.1f".format(actualFPS)} FPS"
+                TAG,
+                "Texture path — $frameCount frames, " +
+                        "target: $targetFPS, actual: ${"%.1f".format(actualFPS)} FPS"
             )
         }
     }
@@ -88,6 +89,15 @@ internal class FrameProcessor {
     fun needsBufferSizeUpdate(width: Int, height: Int): Boolean {
         val bmp = reusableBitmap
         return bmp == null || bmp.width != width || bmp.height != height
+    }
+
+    @Synchronized
+    fun copyAsJpegBytes(quality: Int = 70): ByteArray? {
+        val bmp = reusableBitmap ?: return null
+        val stream = ByteArrayOutputStream()
+        bmp.compress(Bitmap.CompressFormat.JPEG, quality, stream)
+
+        return stream.toByteArray()
     }
 
     fun release() {
@@ -104,7 +114,12 @@ internal class FrameProcessor {
      * Uses BT.601 full-range coefficients with fixed-point integer math (scaled by 1024).
      * Reuses byte/pixel arrays across frames to avoid per-frame GC pressure.
      */
-    private fun convertI420toArgbBitmap(buffer: ByteBuffer, width: Int, height: Int, bitmap: Bitmap) {
+    private fun convertI420toArgbBitmap(
+        buffer: ByteBuffer,
+        width: Int,
+        height: Int,
+        bitmap: Bitmap
+    ) {
         val dataSize = buffer.remaining()
         var byteArray = reusableByteArray
         if (byteArray == null || byteArray.size < dataSize) {

--- a/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
+++ b/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
@@ -48,28 +48,28 @@ import kotlinx.coroutines.sync.withLock
 
 /** MetaWearablesDatPlugin */
 class MetaWearablesDatPlugin :
-        FlutterPlugin,
-        MethodCallHandler,
-        ActivityAware,
-        PluginRegistry.ActivityResultListener,
-        PluginRegistry.RequestPermissionsResultListener {
+    FlutterPlugin,
+    MethodCallHandler,
+    ActivityAware,
+    PluginRegistry.ActivityResultListener,
+    PluginRegistry.RequestPermissionsResultListener {
 
     companion object {
         private const val TAG = "MetaWearablesDat"
         private const val PERMISSION_REQUEST_CODE = 48291
         private const val BT_PERMISSION_REQUEST_CODE = 48292
         private val REQUIRED_PERMISSIONS: Array<String> =
-                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
-                    arrayOf(
-                            android.Manifest.permission.BLUETOOTH_CONNECT,
-                            android.Manifest.permission.INTERNET,
-                    )
-                } else {
-                    arrayOf(
-                            android.Manifest.permission.BLUETOOTH,
-                            android.Manifest.permission.INTERNET,
-                    )
-                }
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                arrayOf(
+                    android.Manifest.permission.BLUETOOTH_CONNECT,
+                    android.Manifest.permission.INTERNET,
+                )
+            } else {
+                arrayOf(
+                    android.Manifest.permission.BLUETOOTH,
+                    android.Manifest.permission.INTERNET,
+                )
+            }
     }
 
     private lateinit var channel: MethodChannel
@@ -77,6 +77,7 @@ class MetaWearablesDatPlugin :
     private lateinit var registrationStateChannel: EventChannel
     private lateinit var streamSessionStateChannel: EventChannel
     private lateinit var streamSessionErrorChannel: EventChannel
+
     private var application: Application? = null
     private var activity: Activity? = null
     private var activityBinding: ActivityPluginBinding? = null
@@ -84,6 +85,7 @@ class MetaWearablesDatPlugin :
     private var registrationStateStreamHandler: RegistrationStateStreamHandler? = null
     private var streamSessionStateStreamHandler: StreamSessionStateStreamHandler? = null
     private var streamSessionErrorStreamHandler: StreamSessionErrorStreamHandler? = null
+
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     // Gate SDK initialization until BT permissions are granted (mirrors reference app).
@@ -116,46 +118,47 @@ class MetaWearablesDatPlugin :
         channel.setMethodCallHandler(this)
 
         activeDeviceChannel =
-                EventChannel(
-                        flutterPluginBinding.binaryMessenger,
-                        "flutter_meta_wearables_dat/active_device"
-                )
+            EventChannel(
+                flutterPluginBinding.binaryMessenger,
+                "flutter_meta_wearables_dat/active_device"
+            )
         activeDeviceStreamHandler =
-                ActiveDeviceStreamHandler(
-                        deviceSelector,
-                        { btPermissionsGranted },
-                        { ensureWearablesInitialized() },
-                )
+            ActiveDeviceStreamHandler(
+                deviceSelector,
+                { btPermissionsGranted },
+                { ensureWearablesInitialized() },
+            )
         activeDeviceChannel.setStreamHandler(activeDeviceStreamHandler)
 
         registrationStateChannel =
-                EventChannel(
-                        flutterPluginBinding.binaryMessenger,
-                        "flutter_meta_wearables_dat/registration_state"
-                )
+            EventChannel(
+                flutterPluginBinding.binaryMessenger,
+                "flutter_meta_wearables_dat/registration_state"
+            )
         registrationStateStreamHandler =
-                RegistrationStateStreamHandler(
-                        { btPermissionsGranted },
-                        { ensureWearablesInitialized() },
-                        ::mapRegistrationState,
-                )
+            RegistrationStateStreamHandler(
+                { btPermissionsGranted },
+                { ensureWearablesInitialized() },
+                ::mapRegistrationState,
+            )
         registrationStateChannel.setStreamHandler(registrationStateStreamHandler)
 
         streamSessionStateChannel =
-                EventChannel(
-                        flutterPluginBinding.binaryMessenger,
-                        "flutter_meta_wearables_dat/stream_session_state"
-                )
+            EventChannel(
+                flutterPluginBinding.binaryMessenger,
+                "flutter_meta_wearables_dat/stream_session_state"
+            )
         streamSessionStateStreamHandler = StreamSessionStateStreamHandler()
         streamSessionStateChannel.setStreamHandler(streamSessionStateStreamHandler)
 
         streamSessionErrorChannel =
-                EventChannel(
-                        flutterPluginBinding.binaryMessenger,
-                        "flutter_meta_wearables_dat/stream_session_errors"
-                )
+            EventChannel(
+                flutterPluginBinding.binaryMessenger,
+                "flutter_meta_wearables_dat/stream_session_errors"
+            )
         streamSessionErrorStreamHandler = StreamSessionErrorStreamHandler()
         streamSessionErrorChannel.setStreamHandler(streamSessionErrorStreamHandler)
+
 
         textureRegistry = flutterPluginBinding.textureRegistry
 
@@ -180,16 +183,19 @@ class MetaWearablesDatPlugin :
             "pairMockRayBanMeta" -> pairMockRayBanMeta(result)
             "unpairMockRayBanMeta" -> unpairMockRayBanMeta(call, result)
             "mockDevicePowerOn", "mockDevicePowerOff", "mockDeviceDon", "mockDeviceDoff" ->
-                    mockDeviceAction(call, result)
+                mockDeviceAction(call, result)
+
             "setMockCameraFeed" -> setMockCameraFeed(call, result)
             "setMockCapturedImage" -> setMockCapturedImage(call, result)
             "restartActiveDeviceMonitoring" -> {
                 activeDeviceStreamHandler?.restartMonitoring()
                 result.success(true)
             }
+
             "startStreamSession" -> startStreamSession(call, result)
             "stopStreamSession" -> stopStreamSession(call, result)
             "capturePhoto" -> capturePhoto(call, result)
+            "captureStreamFrame" -> captureStreamFrame(call, result)
             else -> result.notImplemented()
         }
     }
@@ -264,16 +270,16 @@ class MetaWearablesDatPlugin :
     // region RequestPermissionsResultListener
 
     override fun onRequestPermissionsResult(
-            requestCode: Int,
-            permissions: Array<out String>,
-            grantResults: IntArray
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
     ): Boolean {
         if (requestCode != BT_PERMISSION_REQUEST_CODE) return false
         val pendingResult = btPermissionResult ?: return false
         btPermissionResult = null
         val allGranted =
-                grantResults.isNotEmpty() &&
-                        grantResults.all { it == PackageManager.PERMISSION_GRANTED }
+            grantResults.isNotEmpty() &&
+                    grantResults.all { it == PackageManager.PERMISSION_GRANTED }
         if (allGranted) {
             // Initialize SDK now that BT permissions are granted (mirrors reference app pattern)
             btPermissionsGranted = true
@@ -298,17 +304,17 @@ class MetaWearablesDatPlugin :
         val act = activity
         if (act == null) {
             result.error(
-                    "PERMISSION_ERROR",
-                    "Activity is not available. Ensure the app is in the foreground.",
-                    null
+                "PERMISSION_ERROR",
+                "Activity is not available. Ensure the app is in the foreground.",
+                null
             )
             return
         }
 
         val missingPermissions =
-                REQUIRED_PERMISSIONS.filter {
-                    ContextCompat.checkSelfPermission(act, it) != PackageManager.PERMISSION_GRANTED
-                }
+            REQUIRED_PERMISSIONS.filter {
+                ContextCompat.checkSelfPermission(act, it) != PackageManager.PERMISSION_GRANTED
+            }
 
         if (missingPermissions.isEmpty()) {
             // Permissions already granted — initialize SDK and start monitoring
@@ -322,9 +328,9 @@ class MetaWearablesDatPlugin :
 
         btPermissionResult = result
         ActivityCompat.requestPermissions(
-                act,
-                missingPermissions.toTypedArray(),
-                BT_PERMISSION_REQUEST_CODE,
+            act,
+            missingPermissions.toTypedArray(),
+            BT_PERMISSION_REQUEST_CODE,
         )
     }
 
@@ -336,9 +342,9 @@ class MetaWearablesDatPlugin :
                 result.success(status == PermissionStatus.Granted)
             } catch (e: Exception) {
                 result.error(
-                        "PERMISSION_ERROR",
-                        e.message ?: "Failed to check camera permission status.",
-                        null
+                    "PERMISSION_ERROR",
+                    e.message ?: "Failed to check camera permission status.",
+                    null
                 )
             }
         }
@@ -374,27 +380,27 @@ class MetaWearablesDatPlugin :
                     val act = activity
                     if (act == null) {
                         result.error(
-                                "PERMISSION_ERROR",
-                                "Activity is not available. Ensure the app is in the foreground.",
-                                null
+                            "PERMISSION_ERROR",
+                            "Activity is not available. Ensure the app is in the foreground.",
+                            null
                         )
                         return@withLock
                     }
 
                     val permissionStatus =
-                            suspendCancellableCoroutine<PermissionStatus> { continuation ->
-                                permissionContinuation = continuation
-                                continuation.invokeOnCancellation { permissionContinuation = null }
-                                val intent = permissionContract.createIntent(act, Permission.CAMERA)
-                                act.startActivityForResult(intent, PERMISSION_REQUEST_CODE)
-                            }
+                        suspendCancellableCoroutine<PermissionStatus> { continuation ->
+                            permissionContinuation = continuation
+                            continuation.invokeOnCancellation { permissionContinuation = null }
+                            val intent = permissionContract.createIntent(act, Permission.CAMERA)
+                            act.startActivityForResult(intent, PERMISSION_REQUEST_CODE)
+                        }
 
                     result.success(permissionStatus == PermissionStatus.Granted)
                 } catch (e: Exception) {
                     result.error(
-                            "PERMISSION_ERROR",
-                            e.message ?: "Failed to request permission.",
-                            null
+                        "PERMISSION_ERROR",
+                        e.message ?: "Failed to request permission.",
+                        null
                     )
                 }
             }
@@ -409,9 +415,9 @@ class MetaWearablesDatPlugin :
         val act = activity
         if (act == null) {
             result.error(
-                    "REGISTRATION_ERROR",
-                    "Activity is not available. Ensure the app is in the foreground.",
-                    null
+                "REGISTRATION_ERROR",
+                "Activity is not available. Ensure the app is in the foreground.",
+                null
             )
             return
         }
@@ -428,9 +434,9 @@ class MetaWearablesDatPlugin :
         val act = activity
         if (act == null) {
             result.error(
-                    "UNREGISTRATION_ERROR",
-                    "Activity is not available. Ensure the app is in the foreground.",
-                    null
+                "UNREGISTRATION_ERROR",
+                "Activity is not available. Ensure the app is in the foreground.",
+                null
             )
             return
         }
@@ -440,9 +446,9 @@ class MetaWearablesDatPlugin :
             result.success(true)
         } catch (e: Exception) {
             result.error(
-                    "UNREGISTRATION_ERROR",
-                    e.message ?: "Failed to start unregistration.",
-                    null
+                "UNREGISTRATION_ERROR",
+                e.message ?: "Failed to start unregistration.",
+                null
             )
         }
     }
@@ -460,9 +466,9 @@ class MetaWearablesDatPlugin :
                 result.success(mapRegistrationState(state))
             } catch (e: Exception) {
                 result.error(
-                        "REGISTRATION_ERROR",
-                        e.message ?: "Failed to fetch registration state.",
-                        null
+                    "REGISTRATION_ERROR",
+                    e.message ?: "Failed to fetch registration state.",
+                    null
                 )
             }
         }
@@ -634,7 +640,11 @@ class MetaWearablesDatPlugin :
             if (entry != null) {
                 result.success(entry.id())
             } else {
-                result.error("TEXTURE_REGISTRATION_FAILED", "No texture registered for session $key", null)
+                result.error(
+                    "TEXTURE_REGISTRATION_FAILED",
+                    "No texture registered for session $key",
+                    null
+                )
             }
             return
         }
@@ -649,7 +659,11 @@ class MetaWearablesDatPlugin :
                 // Register a Flutter texture for zero-copy rendering
                 val registry = textureRegistry
                 if (registry == null) {
-                    result.error("TEXTURE_REGISTRATION_FAILED", "TextureRegistry is not available.", null)
+                    result.error(
+                        "TEXTURE_REGISTRATION_FAILED",
+                        "TextureRegistry is not available.",
+                        null
+                    )
                     return@launch
                 }
                 val entry = registry.createSurfaceTexture()
@@ -663,32 +677,36 @@ class MetaWearablesDatPlugin :
                 Log.d(TAG, "Registered texture $textureId for session $key")
 
                 val session =
-                        Wearables.startStreamSession(
-                                app,
-                                deviceSelector,
-                                StreamConfiguration(videoQuality = streamQuality, fps.toInt())
-                        )
+                    Wearables.startStreamSession(
+                        app,
+                        deviceSelector,
+                        StreamConfiguration(videoQuality = streamQuality, fps.toInt())
+                    )
                 streamSession = session
                 streamSessionStateStreamHandler?.session = session
                 streamSessionErrorStreamHandler?.session = session
-
                 // Subscribe to video frames — render I420 → ARGB bitmap → SurfaceTexture
                 videoJob = scope.launch(Dispatchers.Default) {
                     session.videoStream.collect { videoFrame ->
                         // Update SurfaceTexture buffer size if frame dimensions change
-                        if (frameProcessor.needsBufferSizeUpdate(videoFrame.width, videoFrame.height)) {
-                            entry.surfaceTexture().setDefaultBufferSize(videoFrame.width, videoFrame.height)
+                        if (frameProcessor.needsBufferSizeUpdate(
+                                videoFrame.width,
+                                videoFrame.height
+                            )
+                        ) {
+                            entry.surfaceTexture()
+                                .setDefaultBufferSize(videoFrame.width, videoFrame.height)
                         }
                         frameProcessor.processFrame(videoFrame, surface)
                     }
                 }
 
                 stateJob =
-                        scope.launch {
-                            session.state.collect { state ->
-                                Log.d(TAG, "StreamSession [$key] state: $state")
-                            }
+                    scope.launch {
+                        session.state.collect { state ->
+                            Log.d(TAG, "StreamSession [$key] state: $state")
                         }
+                    }
 
                 result.success(textureId)
             } catch (e: Exception) {
@@ -722,53 +740,65 @@ class MetaWearablesDatPlugin :
         val args = call.arguments as? Map<*, *>
         val format = args?.get("format") as? String
         if (format != null) {
-            Log.d(TAG, "capturePhoto format '$format' received (device decides actual format on Android)")
+            Log.d(
+                TAG,
+                "capturePhoto format '$format' received (device decides actual format on Android)"
+            )
         }
 
         scope.launch {
             try {
                 val photoResult = session.capturePhoto()
                 photoResult
-                        .onSuccess { photoData ->
-                            val response: Map<String, Any> =
-                                    when (photoData) {
-                                        is PhotoData.Bitmap -> {
-                                            val stream = ByteArrayOutputStream()
-                                            photoData.bitmap.compress(
-                                                    android.graphics.Bitmap.CompressFormat.JPEG,
-                                                    85,
-                                                    stream
-                                            )
-                                            mapOf(
-                                                    "bytes" to stream.toByteArray(),
-                                                    "format" to "jpeg"
-                                            )
-                                        }
-                                        is PhotoData.HEIC -> {
-                                            val buffer = photoData.data
-                                            val bytes = ByteArray(buffer.remaining())
-                                            buffer.get(bytes)
-                                            mapOf("bytes" to bytes, "format" to "heic")
-                                        }
-                                    }
-                            result.success(response)
-                        }
-                        .onFailure { error, _ ->
-                            val errorCode = when (error) {
-                                is CaptureError.DeviceDisconnected -> "deviceDisconnected"
-                                is CaptureError.NotStreaming -> "notStreaming"
-                                is CaptureError.CaptureInProgress -> "captureInProgress"
-                                is CaptureError.CaptureFailed -> "captureFailed"
+                    .onSuccess { photoData ->
+                        val response: Map<String, Any> =
+                            when (photoData) {
+                                is PhotoData.Bitmap -> {
+                                    val stream = ByteArrayOutputStream()
+                                    photoData.bitmap.compress(
+                                        android.graphics.Bitmap.CompressFormat.JPEG,
+                                        85,
+                                        stream
+                                    )
+                                    mapOf(
+                                        "bytes" to stream.toByteArray(),
+                                        "format" to "jpeg"
+                                    )
+                                }
+
+                                is PhotoData.HEIC -> {
+                                    val buffer = photoData.data
+                                    val bytes = ByteArray(buffer.remaining())
+                                    buffer.get(bytes)
+                                    mapOf("bytes" to bytes, "format" to "heic")
+                                }
                             }
-                            Log.e(TAG, "Photo capture failed: $errorCode - ${error.description}")
-                            streamSessionErrorStreamHandler?.sendError(errorCode, error.description)
-                            result.error("CAPTURE_PHOTO_FAILED", error.description, errorCode)
+                        result.success(response)
+                    }
+                    .onFailure { error, _ ->
+                        val errorCode = when (error) {
+                            is CaptureError.DeviceDisconnected -> "deviceDisconnected"
+                            is CaptureError.NotStreaming -> "notStreaming"
+                            is CaptureError.CaptureInProgress -> "captureInProgress"
+                            is CaptureError.CaptureFailed -> "captureFailed"
                         }
+                        Log.e(TAG, "Photo capture failed: $errorCode - ${error.description}")
+                        streamSessionErrorStreamHandler?.sendError(errorCode, error.description)
+                        result.error("CAPTURE_PHOTO_FAILED", error.description, errorCode)
+                    }
             } catch (e: Exception) {
                 Log.e(TAG, "Photo capture exception", e)
                 result.error("CAPTURE_PHOTO_FAILED", e.message ?: "Photo capture failed.", null)
             }
         }
+    }
+
+    private fun captureStreamFrame(call: MethodCall, result: Result) {
+        val args = call.arguments as? Map<*, *>
+        val quality = ((args?.get("quality") as? Int) ?: 70).coerceIn(1, 100)
+        val bytes = frameProcessor.copyAsJpegBytes(quality)
+
+        result.success(bytes)
     }
 
     private fun cleanupSession() {
@@ -804,7 +834,7 @@ class MetaWearablesDatPlugin :
     }
 
     private fun mapRegistrationState(
-            state: com.meta.wearable.dat.core.types.RegistrationState
+        state: com.meta.wearable.dat.core.types.RegistrationState
     ): Int {
         return when (state) {
             is com.meta.wearable.dat.core.types.RegistrationState.Unavailable -> 0

--- a/ios/Classes/MetaWearablesDatPlugin.swift
+++ b/ios/Classes/MetaWearablesDatPlugin.swift
@@ -723,7 +723,7 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    private static func resolution(forquality _: StreamQuality) -> StreamingResolution {
+    private static func resolution(for quality: StreamQuality) -> StreamingResolution {
         switch quality {
         case .high:
             return .high

--- a/ios/Classes/MetaWearablesDatPlugin.swift
+++ b/ios/Classes/MetaWearablesDatPlugin.swift
@@ -1,684 +1,742 @@
-import Flutter
-import UIKit
-import MWDATCore
-import MWDATCamera
-import MWDATMockDevice
 import AVFoundation
 import CoreMedia
+import Flutter
+import MWDATCamera
+import MWDATCore
+import MWDATMockDevice
+import UIKit
 import VideoToolbox
 
 public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
-  // Single stream session state (only one session at a time)
-  private var streamSession: StreamSession?
-  private var videoListenerToken: (any MWDATCore.AnyListenerToken)?
-  private var errorListenerToken: (any MWDATCore.AnyListenerToken)?
-  private var frameCounter: Int = 0
-  private var currentTargetFPS: Double = 30.0
-  private var lastFrameSendTime: Date?
-  private var pixelBufferTexture: PixelBufferTexture?
-  private var textureId: Int64?
-  private var currentVideoCodec: MWDATCamera.VideoCodec = .raw
-  private var decompressionSession: VTDecompressionSession?
-  // Texture registry
-  private var textureRegistry: FlutterTextureRegistry?
-  // Stream session event handlers
-  private var streamStateHandler = StreamSessionStateStreamHandler()
-  private var streamErrorHandler = StreamSessionErrorStreamHandler()
+    // Single stream session state (only one session at a time)
+    private var streamSession: StreamSession?
+    private var videoListenerToken: (any MWDATCore.AnyListenerToken)?
+    private var errorListenerToken: (any MWDATCore.AnyListenerToken)?
+    private var frameCounter: Int = 0
+    private var currentTargetFPS: Double = 30.0
+    private var lastFrameSendTime: Date?
+    private var pixelBufferTexture: PixelBufferTexture?
+    private var textureId: Int64?
+    private var currentVideoCodec: MWDATCamera.VideoCodec = .raw
+    private var decompressionSession: VTDecompressionSession?
+    // Texture registry
+    private var textureRegistry: FlutterTextureRegistry?
+    // Stream session event handlers
+    private var streamStateHandler = StreamSessionStateStreamHandler()
+    private var streamErrorHandler = StreamSessionErrorStreamHandler()
 
-  public static func register(with registrar: FlutterPluginRegistrar) {
-    let channel = FlutterMethodChannel(name: "flutter_meta_wearables_dat", binaryMessenger: registrar.messenger())
-    let instance = MetaWearablesDatPlugin()
-    instance.textureRegistry = registrar.textures()
-    registrar.addMethodCallDelegate(instance, channel: channel)
-    // Event channel for registration state updates
-    let registrationStateChannel = FlutterEventChannel(name: "flutter_meta_wearables_dat/registration_state", binaryMessenger: registrar.messenger())
-    registrationStateChannel.setStreamHandler(RegistrationStateStreamHandler())
-    // Event channel for active device availability updates
-    let activeDeviceChannel = FlutterEventChannel(name: "flutter_meta_wearables_dat/active_device", binaryMessenger: registrar.messenger())
-    activeDeviceChannel.setStreamHandler(ActiveDeviceStreamHandler())
-    // Event channels for stream session state and errors
-    let streamStateChannel = FlutterEventChannel(name: "flutter_meta_wearables_dat/stream_session_state", binaryMessenger: registrar.messenger())
-    streamStateChannel.setStreamHandler(instance.streamStateHandler)
-    let streamErrorChannel = FlutterEventChannel(name: "flutter_meta_wearables_dat/stream_session_errors", binaryMessenger: registrar.messenger())
-    streamErrorChannel.setStreamHandler(instance.streamErrorHandler)
+    public static func register(with registrar: FlutterPluginRegistrar) {
+        let channel = FlutterMethodChannel(name: "flutter_meta_wearables_dat", binaryMessenger: registrar.messenger())
+        let instance = MetaWearablesDatPlugin()
+        instance.textureRegistry = registrar.textures()
+        registrar.addMethodCallDelegate(instance, channel: channel)
+        // Event channel for registration state updates
+        let registrationStateChannel = FlutterEventChannel(name: "flutter_meta_wearables_dat/registration_state", binaryMessenger: registrar.messenger())
+        registrationStateChannel.setStreamHandler(RegistrationStateStreamHandler())
+        // Event channel for active device availability updates
+        let activeDeviceChannel = FlutterEventChannel(name: "flutter_meta_wearables_dat/active_device", binaryMessenger: registrar.messenger())
+        activeDeviceChannel.setStreamHandler(ActiveDeviceStreamHandler())
+        // Event channels for stream session state and errors
+        let streamStateChannel = FlutterEventChannel(name: "flutter_meta_wearables_dat/stream_session_state", binaryMessenger: registrar.messenger())
+        streamStateChannel.setStreamHandler(instance.streamStateHandler)
+        let streamErrorChannel = FlutterEventChannel(name: "flutter_meta_wearables_dat/stream_session_errors", binaryMessenger: registrar.messenger())
+        streamErrorChannel.setStreamHandler(instance.streamErrorHandler)
 
-    Task { @MainActor in
-      try? Wearables.configure()
-    }
-  }
-
-  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    switch call.method {
-      case "pairMockRayBanMeta":
-        pairMockRayBanMeta(result: result)
-      case "unpairMockRayBanMeta":
-        unpairMockRayBanMeta(call: call, result: result)
-      case "mockDevicePowerOn":
-        mockDeviceAction(call: call, result: result) { device in
-          device.powerOn()
+        Task { @MainActor in
+            try? Wearables.configure()
         }
-      case "mockDevicePowerOff":
-        mockDeviceAction(call: call, result: result) { device in
-          device.powerOff()
-        }
-      case "mockDeviceDon":
-        mockDeviceAction(call: call, result: result) { device in
-          device.don()
-        }
-      case "mockDeviceDoff":
-        mockDeviceAction(call: call, result: result) { device in
-          device.doff()
-        }
-      case "requestAndroidPermissions":
-        // No-op on iOS — Android-only runtime permissions
-        result(true)
-      case "restartActiveDeviceMonitoring":
-        // No-op on iOS — Android-only workaround for device flow timing
-        result(true)
-      case "startRegistration":
-        startRegistration(result: result)
-      case "disconnect":
-        disconnect(result: result)
-      case "handleUrl":
-        handleUrl(call: call, result: result)
-      case "getCameraPermissionStatus":
-        getCameraPermissionStatus(result: result)
-      case "requestCameraPermission":
-        requestCameraPermission(result: result)
-      case "setMockCameraFeed":
-        setMockCameraFeed(call: call, result: result)
-      case "setMockCapturedImage":
-        setMockCapturedImage(call: call, result: result)
-      case "startStreamSession":
-        startStreamSession(call: call, result: result)
-      case "stopStreamSession":
-        stopStreamSession(call: call, result: result)
-      case "capturePhoto":
-        capturePhoto(call: call, result: result)
-      case "getRegistrationState":
-        getRegistrationState(result: result)
-      default:
-        result(FlutterMethodNotImplemented)
-    }
-  }
-
-  func pairMockRayBanMeta(result: @escaping FlutterResult) {
-    Task { @MainActor in
-      let mockDevice = MockDeviceKit.shared.pairRaybanMeta()
-      result(mockDevice.deviceIdentifier)
-    }
-  }
-
-  func unpairMockRayBanMeta(call: FlutterMethodCall, result: @escaping FlutterResult) {
-    guard let args = call.arguments as? [String : Any], let uuidString = args["deviceUUID"] as? String else {
-      result(FlutterError(code: "INVALID_ARGS", message: "deviceUUID missing", details: nil))
-      return
-    }
-    Task { @MainActor in
-      let devices = MockDeviceKit.shared.pairedDevices
-      guard let device = devices.first(where: { $0.deviceIdentifier == uuidString }) else {
-        result(FlutterError(code: "DEVICE_NOT_FOUND", message: "No mock device with uuid \(uuidString)", details: nil))
-        return
-      }
-
-      // Clean up active stream session if any
-      await cleanupSession()
-
-      MockDeviceKit.shared.unpairDevice(device)
-      result(true)
-    }
-  }
-
-  private func mockDeviceAction(call: FlutterMethodCall, result: @escaping FlutterResult, perform: @escaping @MainActor (any MWDATMockDevice.MockDevice) -> Void) {
-    guard let args = call.arguments as? [String : Any], let uuidString = args["deviceUUID"] as? String else {
-      result(FlutterError(code: "INVALID_ARGS", message: "deviceUUID missing", details: nil))
-      return
     }
 
-    Task { @MainActor in
-      let devices = MockDeviceKit.shared.pairedDevices
-      guard let device = devices.first(where: { $0.deviceIdentifier == uuidString }) else {
-        result(FlutterError(code: "DEVICE_NOT_FOUND", message: "No mock device with uuid \(uuidString)", details: nil))
-        return
-      }
-      perform(device)
-      result(true)
-    }
-  }
-
-  func requestCameraPermission(result: @escaping FlutterResult) {
-    Task { @MainActor in
-      do {
-        let currentStatus = try await Wearables.shared.checkPermissionStatus(.camera)
-        if currentStatus == .granted {
-          result(true)
-          return
-        }
-
-        let status = try await Wearables.shared.requestPermission(.camera)
-        // Convert PermissionStatus enum to Bool for Flutter
-        let granted = status == .granted
-        result(granted)
-      } catch let e as MWDATCore.PermissionError {
-        result(FlutterError(code: "PERMISSION_ERROR", message: e.localizedDescription, details: e.rawValue))
-      } catch {
-        result(FlutterError(code: "PERMISSION_ERROR", message: error.localizedDescription, details: nil))
-      }
-    }
-  }
-
-  func getCameraPermissionStatus(result: @escaping FlutterResult) {
-    Task { @MainActor in
-      do {
-        let status = try await Wearables.shared.checkPermissionStatus(.camera)
-        result(status == .granted)
-      } catch is MWDATCore.PermissionError {
-        // Permission not granted yet or denied — return false instead of error
-        result(false)
-      } catch {
-        result(FlutterError(code: "PERMISSION_ERROR", message: error.localizedDescription, details: nil))
-      }
-    }
-  }
-
-  func startRegistration(result: @escaping FlutterResult) {
-    Task { @MainActor in
-      do {
-        try await Wearables.shared.startRegistration()
-        result(true)
-      } catch let e as MWDATCore.RegistrationError {
-        let errorMessage: String
-        switch e {
-        case .alreadyRegistered:
-          errorMessage = "User is already registered. Registration is not needed."
-        case .configurationInvalid:
-          errorMessage = "SDK configuration is invalid or incomplete."
-        case .metaAINotInstalled:
-          errorMessage = "Meta AI app is not installed. Please install it to proceed with registration."
-        case .networkUnavailable:
-          errorMessage = "Network connection is unavailable. Please check your internet connection and try again."
-        case .unknown:
-          errorMessage = "An unknown error occurred during registration."
-        @unknown default:
-          errorMessage = "Unknown registration error: \(e)"
-        }
-        result(FlutterError(code: "REGISTRATION_ERROR", message: errorMessage, details: e.rawValue))
-      } catch {
-        result(FlutterError(code: "REGISTRATION_ERROR", message: error.localizedDescription, details: nil))
-      }
-    }
-  }
-
-  func disconnect(result: @escaping FlutterResult) {
-    Task { @MainActor in
-      do {
-        try await Wearables.shared.startUnregistration()
-        result(true)
-      } catch let e as MWDATCore.UnregistrationError {
-        let errorMessage: String
-        switch e {
-        case .alreadyUnregistered:
-          errorMessage = "User is already unregistered."
-        case .configurationInvalid:
-          errorMessage = "SDK configuration is invalid or incomplete."
-        case .metaAINotInstalled:
-          errorMessage = "Meta AI app is not installed. Please install it to proceed with unregistration."
-        case .unknown:
-          errorMessage = "An unknown error occurred during unregistration."
-        @unknown default:
-          errorMessage = "Unknown unregistration error: \(e)"
-        }
-        result(FlutterError(code: "UNREGISTRATION_ERROR", message: errorMessage, details: e.rawValue))
-      } catch {
-        result(FlutterError(code: "UNREGISTRATION_ERROR", message: error.localizedDescription, details: nil))
-      }
-    }
-  }
-
-  func handleUrl(call: FlutterMethodCall, result: @escaping FlutterResult) {
-    guard let args = call.arguments as? [String : Any], let urlString = args["url"] as? String else {
-      result(FlutterError(code: "INVALID_ARGS", message: "url missing", details: nil))
-      return
-    }
-
-    guard let url = URL(string: urlString) else {
-      result(FlutterError(code: "INVALID_URL", message: "Could not parse URL: \(urlString)", details: nil))
-      return
-    }
-
-    Task { @MainActor in
-      do {
-        let handled = try await Wearables.shared.handleUrl(url)
-        result(handled)
-      } catch let e as MWDATCore.RegistrationError {
-        result(FlutterError(code: "REGISTRATION_ERROR", message: "\(e)", details: e.rawValue))
-      } catch {
-        result(FlutterError(code: "HANDLE_URL_ERROR", message: error.localizedDescription, details: nil))
-      }
-    }
-  }
-
-  // MARK: - Session Cleanup
-
-  /// Single source of truth for tearing down the current stream session.
-  /// Safe to call even when no session is active.
-  private func cleanupSession() async {
-    if let token = videoListenerToken {
-      await token.cancel()
-      videoListenerToken = nil
-    }
-    if let token = errorListenerToken {
-      await token.cancel()
-      errorListenerToken = nil
-    }
-    // Disconnect event handlers
-    streamStateHandler.session = nil
-    streamErrorHandler.session = nil
-    if let session = streamSession {
-      await session.stop()
-      streamSession = nil
-    }
-    if let texId = textureId {
-      textureRegistry?.unregisterTexture(texId)
-      NSLog("[MWDAT] Unregistered texture \(texId)")
-      textureId = nil
-      pixelBufferTexture = nil
-    }
-    if let session = decompressionSession {
-      VTDecompressionSessionInvalidate(session)
-      decompressionSession = nil
-    }
-    frameCounter = 0
-    lastFrameSendTime = nil
-  }
-
-  // MARK: - Frame Processing (zero-copy via Texture API)
-  /// Pushes a CVPixelBuffer extracted from the VideoFrame's CMSampleBuffer
-  /// directly to the Flutter texture — no JPEG encode/decode, no byte copy.
-  private func processAndSendFrame(_ videoFrame: VideoFrame) {
-    let now = Date()
-    let minInterval = 1.0 / currentTargetFPS
-
-    let timeSinceLastFrame: TimeInterval
-    if let lastSendTime = lastFrameSendTime {
-      timeSinceLastFrame = now.timeIntervalSince(lastSendTime)
-      if timeSinceLastFrame < minInterval {
-        return // throttle
-      }
-    } else {
-      timeSinceLastFrame = 0
-    }
-
-    // Get pixel buffer: direct extraction for raw, decode for hvc1
-    let pixelBuffer: CVPixelBuffer?
-    if currentVideoCodec == .raw {
-      pixelBuffer = CMSampleBufferGetImageBuffer(videoFrame.sampleBuffer)
-    } else {
-      pixelBuffer = decodeCompressedFrame(videoFrame.sampleBuffer)
-    }
-
-    guard let pixelBuffer else {
-      NSLog("[MWDAT] Could not obtain pixel buffer from video frame")
-      return
-    }
-
-    guard let texture = pixelBufferTexture,
-          let texId = textureId else {
-      return
-    }
-
-    // Swap the pixel buffer (lock-protected) and notify Flutter's rasteriser
-    texture.latestPixelBuffer = pixelBuffer
-    textureRegistry?.textureFrameAvailable(texId)
-
-    // Update timing + counters
-    lastFrameSendTime = now
-    frameCounter += 1
-
-    if frameCounter % 30 == 0 && timeSinceLastFrame > 0 {
-      let actualFPS = 1.0 / timeSinceLastFrame
-      NSLog("[MWDAT] \(frameCounter) frames, target: \(currentTargetFPS), actual: \(String(format: "%.1f", actualFPS)) FPS")
-    }
-  }
-
-  // MARK: - HEVC Decompression (for hvc1 codec)
-
-  /// Creates a VTDecompressionSession for decoding HEVC frames to BGRA pixel buffers.
-  private func setupDecompressionSession(formatDescription: CMFormatDescription) {
-    let attrs: [String: Any] = [
-      kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
-    ]
-    var session: VTDecompressionSession?
-    let status = VTDecompressionSessionCreate(
-      allocator: kCFAllocatorDefault,
-      formatDescription: formatDescription,
-      decoderSpecification: nil,
-      imageBufferAttributes: attrs as CFDictionary,
-      outputCallback: nil,
-      decompressionSessionOut: &session
-    )
-    if status == noErr, let session {
-      decompressionSession = session
-      NSLog("[MWDAT] Created VTDecompressionSession for HEVC decoding")
-    } else {
-      NSLog("[MWDAT] Failed to create VTDecompressionSession: \(status)")
-    }
-  }
-
-  /// Decodes a compressed CMSampleBuffer (HEVC) to a CVPixelBuffer.
-  private func decodeCompressedFrame(_ sampleBuffer: CMSampleBuffer) -> CVPixelBuffer? {
-    guard let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer) else {
-      return nil
-    }
-
-    // Lazily create decompression session on first frame
-    if decompressionSession == nil {
-      setupDecompressionSession(formatDescription: formatDescription)
-    }
-
-    guard let session = decompressionSession else { return nil }
-
-    var outputBuffer: CVPixelBuffer?
-    var flagOut: VTDecodeInfoFlags = []
-
-    let status = VTDecompressionSessionDecodeFrame(
-      session,
-      sampleBuffer: sampleBuffer,
-      flags: [],  // synchronous decode
-      infoFlagsOut: &flagOut,
-      outputHandler: { decodeStatus, _, imageBuffer, _, _ in
-        if decodeStatus == noErr {
-          outputBuffer = imageBuffer
-        }
-      }
-    )
-
-    if status != noErr {
-      NSLog("[MWDAT] VTDecompressionSession decode error: \(status)")
-      return nil
-    }
-
-    return outputBuffer
-  }
-
-  func setMockCameraFeed(call: FlutterMethodCall, result: @escaping FlutterResult) {
-    guard let args = call.arguments as? [String : Any],
-          let uuidString = args["deviceUUID"] as? String else {
-      result(FlutterError(code: "INVALID_ARGS", message: "deviceUUID missing", details: nil))
-      return
-    }
-
-    Task { @MainActor in
-      let devices = MockDeviceKit.shared.pairedDevices
-      guard let device = devices.first(where: { $0.deviceIdentifier == uuidString }) else {
-        result(FlutterError(code: "DEVICE_NOT_FOUND", message: "No mock device with uuid \(uuidString)", details: nil))
-        return
-      }
-
-      guard let mockDisplaylessGlasses = device as? any MWDATMockDevice.MockDisplaylessGlasses else {
-        result(FlutterError(code: "INVALID_DEVICE_TYPE", message: "Device does not support camera", details: nil))
-        return
-      }
-
-      let cameraKit = mockDisplaylessGlasses.getCameraKit()
-
-      if let videoPath = args["videoPath"] as? String, !videoPath.isEmpty {
-        let fileURL = URL(fileURLWithPath: videoPath)
-
-        // Validate file exists
-        let fileManager = FileManager.default
-        if !fileManager.fileExists(atPath: videoPath) {
-          result(FlutterError(code: "FILE_NOT_FOUND", message: "Video file not found at path: \(videoPath)", details: nil))
-          return
-        }
-
-        // Validate video codec - must be HEVC/H.265
-        let asset = AVAsset(url: fileURL)
-        let tracks = try? await asset.loadTracks(withMediaType: .video)
-        var foundHEVC = false
-
-        if let videoTracks = tracks {
-          for videoTrack in videoTracks {
-            if let formatDescriptions = try? await videoTrack.load(.formatDescriptions) as? [CMFormatDescription],
-               let formatDescription = formatDescriptions.first {
-              let codecType = CMFormatDescriptionGetMediaSubType(formatDescription)
-              let codecString = String(format: "%c%c%c%c",
-                                      (codecType >> 24) & 0xFF,
-                                      (codecType >> 16) & 0xFF,
-                                      (codecType >> 8) & 0xFF,
-                                      codecType & 0xFF)
-
-              if codecType == kCMVideoCodecType_HEVC ||
-                 codecString == "hvc1" ||
-                 codecString == "hev1" {
-                foundHEVC = true
-                break
-              }
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        switch call.method {
+        case "pairMockRayBanMeta":
+            pairMockRayBanMeta(result: result)
+        case "unpairMockRayBanMeta":
+            unpairMockRayBanMeta(call: call, result: result)
+        case "mockDevicePowerOn":
+            mockDeviceAction(call: call, result: result) {
+                device in
+                device.powerOn()
             }
-          }
+        case "mockDevicePowerOff":
+            mockDeviceAction(call: call, result: result) {
+                device in
+                device.powerOff()
+            }
+        case "mockDeviceDon":
+            mockDeviceAction(call: call, result: result) {
+                device in
+                device.don()
+            }
+        case "mockDeviceDoff":
+            mockDeviceAction(call: call, result: result) {
+                device in
+                device.doff()
+            }
+        case "requestAndroidPermissions":
+            // No-op on iOS — Android-only runtime permissions
+            result(true)
+        case "restartActiveDeviceMonitoring":
+            // No-op on iOS — Android-only workaround for device flow timing
+            result(true)
+        case "startRegistration":
+            startRegistration(result: result)
+        case "disconnect":
+            disconnect(result: result)
+        case "handleUrl":
+            handleUrl(call: call, result: result)
+        case "getCameraPermissionStatus":
+            getCameraPermissionStatus(result: result)
+        case "requestCameraPermission":
+            requestCameraPermission(result: result)
+        case "setMockCameraFeed":
+            setMockCameraFeed(call: call, result: result)
+        case "setMockCapturedImage":
+            setMockCapturedImage(call: call, result: result)
+        case "startStreamSession":
+            startStreamSession(call: call, result: result)
+        case "stopStreamSession":
+            stopStreamSession(call: call, result: result)
+        case "capturePhoto":
+            capturePhoto(call: call, result: result)
+        case "captureStreamFrame":
+            captureStreamFrame(call: call, result: result)
+        case "getRegistrationState":
+            getRegistrationState(result: result)
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    func pairMockRayBanMeta(result: @escaping FlutterResult) {
+        Task {
+            @MainActor in
+            let mockDevice = MockDeviceKit.shared.pairRaybanMeta()
+            result(mockDevice.deviceIdentifier)
+        }
+    }
+
+    func unpairMockRayBanMeta(call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any], let uuidString = args["deviceUUID"] as? String else {
+            result(FlutterError(code: "INVALID_ARGS", message: "deviceUUID missing", details: nil))
+            return
+        }
+        Task {
+            @MainActor in
+            let devices = MockDeviceKit.shared.pairedDevices
+            guard let device = devices.first(where: {
+                $0.deviceIdentifier == uuidString
+            }) else {
+                result(FlutterError(code: "DEVICE_NOT_FOUND", message: "No mock device with uuid \(uuidString)", details: nil))
+                return
+            }
+
+            // Clean up active stream session if any
+            await cleanupSession()
+
+            MockDeviceKit.shared.unpairDevice(device)
+            result(true)
+        }
+    }
+
+    private func mockDeviceAction(call: FlutterMethodCall, result: @escaping FlutterResult, perform: @escaping @MainActor (any MWDATMockDevice.MockDevice) -> Void) {
+        guard let args = call.arguments as? [String: Any], let uuidString = args["deviceUUID"] as? String else {
+            result(FlutterError(code: "INVALID_ARGS", message: "deviceUUID missing", details: nil))
+            return
         }
 
-        if !foundHEVC {
-          result(FlutterError(code: "INVALID_CODEC", message: "Video must be HEVC/H.265 format. Use file_picker (not image_picker) to preserve original format.", details: nil))
-          return
+        Task {
+            @MainActor in
+            let devices = MockDeviceKit.shared.pairedDevices
+            guard let device = devices.first(where: {
+                $0.deviceIdentifier == uuidString
+            }) else {
+                result(FlutterError(code: "DEVICE_NOT_FOUND", message: "No mock device with uuid \(uuidString)", details: nil))
+                return
+            }
+            perform(device)
+            result(true)
+        }
+    }
+
+    func requestCameraPermission(result: @escaping FlutterResult) {
+        Task {
+            @MainActor in
+            do {
+                let currentStatus = try await Wearables.shared.checkPermissionStatus(.camera)
+                if currentStatus == .granted {
+                    result(true)
+                    return
+                }
+
+                let status = try await Wearables.shared.requestPermission(.camera)
+                // Convert PermissionStatus enum to Bool for Flutter
+                let granted = status == .granted
+                result(granted)
+            } catch let e as MWDATCore.PermissionError {
+                result(FlutterError(code: "PERMISSION_ERROR", message: e.localizedDescription, details: e.rawValue))
+            } catch {
+                result(FlutterError(code: "PERMISSION_ERROR", message: error.localizedDescription, details: nil))
+            }
+        }
+    }
+
+    func getCameraPermissionStatus(result: @escaping FlutterResult) {
+        Task {
+            @MainActor in
+            do {
+                let status = try await Wearables.shared.checkPermissionStatus(.camera)
+                result(status == .granted)
+            } catch is MWDATCore.PermissionError {
+                // Permission not granted yet or denied — return false instead of error
+                result(false)
+            } catch {
+                result(FlutterError(code: "PERMISSION_ERROR", message: error.localizedDescription, details: nil))
+            }
+        }
+    }
+
+    func startRegistration(result: @escaping FlutterResult) {
+        Task {
+            @MainActor in
+            do {
+                try await Wearables.shared.startRegistration()
+                result(true)
+            } catch let e as MWDATCore.RegistrationError {
+                let errorMessage: String
+                switch e {
+                case .alreadyRegistered:
+                    errorMessage = "User is already registered. Registration is not needed."
+                case .configurationInvalid:
+                    errorMessage = "SDK configuration is invalid or incomplete."
+                case .metaAINotInstalled:
+                    errorMessage = "Meta AI app is not installed. Please install it to proceed with registration."
+                case .networkUnavailable:
+                    errorMessage = "Network connection is unavailable. Please check your internet connection and try again."
+                case .unknown:
+                    errorMessage = "An unknown error occurred during registration."
+                @unknown default:
+                    errorMessage = "Unknown registration error: \(e)"
+                }
+                result(FlutterError(code: "REGISTRATION_ERROR", message: errorMessage, details: e.rawValue))
+            } catch {
+                result(FlutterError(code: "REGISTRATION_ERROR", message: error.localizedDescription, details: nil))
+            }
+        }
+    }
+
+    func disconnect(result: @escaping FlutterResult) {
+        Task {
+            @MainActor in
+            do {
+                try await Wearables.shared.startUnregistration()
+                result(true)
+            } catch let e as MWDATCore.UnregistrationError {
+                let errorMessage: String
+                switch e {
+                case .alreadyUnregistered:
+                    errorMessage = "User is already unregistered."
+                case .configurationInvalid:
+                    errorMessage = "SDK configuration is invalid or incomplete."
+                case .metaAINotInstalled:
+                    errorMessage = "Meta AI app is not installed. Please install it to proceed with unregistration."
+                case .unknown:
+                    errorMessage = "An unknown error occurred during unregistration."
+                @unknown default:
+                    errorMessage = "Unknown unregistration error: \(e)"
+                }
+                result(FlutterError(code: "UNREGISTRATION_ERROR", message: errorMessage, details: e.rawValue))
+            } catch {
+                result(FlutterError(code: "UNREGISTRATION_ERROR", message: error.localizedDescription, details: nil))
+            }
+        }
+    }
+
+    func handleUrl(call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any], let urlString = args["url"] as? String else {
+            result(FlutterError(code: "INVALID_ARGS", message: "url missing", details: nil))
+            return
         }
 
-        await cameraKit.setCameraFeed(fileURL: fileURL)
-        result(true)
-      } else {
-        result(true)
-      }
-    }
-  }
+        guard let url = URL(string: urlString) else {
+            result(FlutterError(code: "INVALID_URL", message: "Could not parse URL: \(urlString)", details: nil))
+            return
+        }
 
-  func setMockCapturedImage(call: FlutterMethodCall, result: @escaping FlutterResult) {
-    guard let args = call.arguments as? [String : Any],
-          let uuidString = args["deviceUUID"] as? String else {
-      result(FlutterError(code: "INVALID_ARGS", message: "deviceUUID missing", details: nil))
-      return
-    }
-
-    Task { @MainActor in
-      let devices = MockDeviceKit.shared.pairedDevices
-      guard let device = devices.first(where: { $0.deviceIdentifier == uuidString }) else {
-        result(FlutterError(code: "DEVICE_NOT_FOUND", message: "No mock device with uuid \(uuidString)", details: nil))
-        return
-      }
-
-      guard let mockDisplaylessGlasses = device as? any MWDATMockDevice.MockDisplaylessGlasses else {
-        result(FlutterError(code: "INVALID_DEVICE_TYPE", message: "Device does not support camera", details: nil))
-        return
-      }
-
-      let cameraKit = mockDisplaylessGlasses.getCameraKit()
-
-      if let imagePath = args["imagePath"] as? String, !imagePath.isEmpty {
-        let fileURL = URL(fileURLWithPath: imagePath)
-        await cameraKit.setCapturedImage(fileURL: fileURL)
-        result(true)
-      } else {
-        // If imagePath is nil or empty, we could clear the image or just return success
-        result(true)
-      }
-    }
-  }
-
-  func startStreamSession(call: FlutterMethodCall, result: @escaping FlutterResult) {
-    guard let args = call.arguments as? [String : Any] else {
-      result(FlutterError(code: "INVALID_ARGS", message: "arguments missing", details: nil))
-      return
+        Task {
+            @MainActor in
+            do {
+                let handled = try await Wearables.shared.handleUrl(url)
+                result(handled)
+            } catch let e as MWDATCore.RegistrationError {
+                result(FlutterError(code: "REGISTRATION_ERROR", message: "\(e)", details: e.rawValue))
+            } catch {
+                result(FlutterError(code: "HANDLE_URL_ERROR", message: error.localizedDescription, details: nil))
+            }
+        }
     }
 
-    // Get FPS parameter (default to 30.0 if not provided)
-    let fps = (args["fps"] as? Double) ?? 30.0
-    let streamQuality = Self.parseStreamQuality(args["streamQuality"] as? String)
-    let videoCodecStr = args["videoCodec"] as? String ?? "raw"
-    let videoCodec: MWDATCamera.VideoCodec = (videoCodecStr == "hvc1") ? .hvc1 : .raw
+    // MARK: - Session Cleanup
 
-    // deviceUUID is optional - if not provided, use AutoDeviceSelector
-    let uuidString = args["deviceUUID"] as? String
-
-    Task { @MainActor in
-      // Determine device selector
-      let deviceSelector: any DeviceSelector
-      if let uuidString = uuidString {
-        deviceSelector = SpecificDeviceSelector(device: uuidString)
-      } else {
-        deviceSelector = AutoDeviceSelector(wearables: Wearables.shared)
-      }
-
-      // Return existing texture if session is already active
-      if streamSession != nil {
+    /// Single source of truth for tearing down the current stream session.
+    /// Safe to call even when no session is active.
+    private func cleanupSession() async {
+        if let token = videoListenerToken {
+            await token.cancel()
+            videoListenerToken = nil
+        }
+        if let token = errorListenerToken {
+            await token.cancel()
+            errorListenerToken = nil
+        }
+        // Disconnect event handlers
+        streamStateHandler.session = nil
+        streamErrorHandler.session = nil
+        if let session = streamSession {
+            await session.stop()
+            streamSession = nil
+        }
         if let texId = textureId {
-          result(texId)
+            textureRegistry?.unregisterTexture(texId)
+            NSLog("[MWDAT] Unregistered texture \(texId)")
+            textureId = nil
+            pixelBufferTexture = nil
+        }
+        if let session = decompressionSession {
+            VTDecompressionSessionInvalidate(session)
+            decompressionSession = nil
+        }
+        frameCounter = 0
+        lastFrameSendTime = nil
+    }
+
+    // MARK: - Frame Processing (zero-copy via Texture API)
+
+    /// Pushes a CVPixelBuffer extracted from the VideoFrame's CMSampleBuffer
+    /// directly to the Flutter texture — no JPEG encode/decode, no byte copy.
+    private func processAndSendFrame(_ videoFrame: VideoFrame) {
+        let now = Date()
+        let minInterval = 1.0 / currentTargetFPS
+
+        let timeSinceLastFrame: TimeInterval
+        if let lastSendTime = lastFrameSendTime {
+            timeSinceLastFrame = now.timeIntervalSince(lastSendTime)
+            if timeSinceLastFrame < minInterval {
+                return // throttle
+            }
         } else {
-          result(FlutterError(code: "TEXTURE_ERROR", message: "Session exists but no texture registered", details: nil))
-        }
-        return
-      }
-
-      // Register a Flutter texture
-      guard let registry = textureRegistry else {
-        result(FlutterError(code: "TEXTURE_ERROR", message: "Texture registry not available", details: nil))
-        return
-      }
-      let texture = PixelBufferTexture()
-      let texId = registry.register(texture)
-      pixelBufferTexture = texture
-      textureId = texId
-      currentTargetFPS = fps
-      currentVideoCodec = videoCodec
-      frameCounter = 0
-      lastFrameSendTime = nil
-      NSLog("[MWDAT] Registered texture \(texId)")
-
-      // Create a new StreamSession
-      let fpsValue = UInt(max(1, Int(fps.rounded())))
-      let streamConfig = StreamSessionConfig(
-        videoCodec: videoCodec,
-        resolution: Self.resolution(for: streamQuality),
-        frameRate: fpsValue
-      )
-      let session = StreamSession(
-        streamSessionConfig: streamConfig,
-        deviceSelector: deviceSelector
-      )
-
-      // Observe errors
-      errorListenerToken = session.errorPublisher.listen { error in
-        NSLog("[MWDAT] StreamSession error: \(error)")
-      }
-
-      // Store the session and connect event handlers
-      streamSession = session
-      streamStateHandler.session = session
-      streamErrorHandler.session = session
-
-      // Subscribe to video frames — push CVPixelBuffer directly, no encoding
-      videoListenerToken = session.videoFramePublisher.listen { [weak self] videoFrame in
-        guard let self else { return }
-        self.processAndSendFrame(videoFrame)
-      }
-
-      // Start the session
-      do {
-        await session.start()
-
-        if uuidString == nil, let activeDevice = deviceSelector.activeDevice {
-          NSLog("[MWDAT] AutoDeviceSelector connected to device: \(activeDevice)")
+            timeSinceLastFrame = 0
         }
 
-        result(texId)
-      } catch {
-        // Clean up on failure
-        await cleanupSession()
-        result(FlutterError(code: "STREAM_SESSION_ERROR", message: error.localizedDescription, details: nil))
-      }
+        // Get pixel buffer: direct extraction for raw, decode for hvc1
+        let pixelBuffer: CVPixelBuffer?
+        if currentVideoCodec == .raw {
+            pixelBuffer = CMSampleBufferGetImageBuffer(videoFrame.sampleBuffer)
+        } else {
+            pixelBuffer = decodeCompressedFrame(videoFrame.sampleBuffer)
+        }
+
+        guard let pixelBuffer else {
+            NSLog("[MWDAT] Could not obtain pixel buffer from video frame")
+            return
+        }
+
+        guard let texture = pixelBufferTexture,
+              let texId = textureId
+        else {
+            return
+        }
+
+        // Swap the pixel buffer (lock-protected) and notify Flutter's rasteriser
+        texture.latestPixelBuffer = pixelBuffer
+        textureRegistry?.textureFrameAvailable(texId)
+
+        // Update timing + counters
+        lastFrameSendTime = now
+        frameCounter += 1
+
+        if frameCounter % 30 == 0, timeSinceLastFrame > 0 {
+            let actualFPS = 1.0 / timeSinceLastFrame
+            NSLog("[MWDAT] \(frameCounter) frames, target: \(currentTargetFPS), actual: \(String(format: "%.1f", actualFPS)) FPS")
+        }
     }
-  }
 
-  func stopStreamSession(call: FlutterMethodCall, result: @escaping FlutterResult) {
-    Task { @MainActor in
-      guard streamSession != nil else {
-        result(FlutterError(code: "SESSION_NOT_FOUND", message: "No active stream session", details: nil))
-        return
-      }
+    // MARK: - HEVC Decompression (for hvc1 codec)
 
-      await cleanupSession()
-      result(true)
-    }
-  }
-
-  func capturePhoto(call: FlutterMethodCall, result: @escaping FlutterResult) {
-    let args = call.arguments as? [String: Any]
-    let formatStr = args?["format"] as? String ?? "jpeg"
-    let captureFormat: MWDATCamera.PhotoCaptureFormat = (formatStr == "heic") ? .heic : .jpeg
-
-    Task { @MainActor in
-      guard let streamSession else {
-        result(FlutterError(code: "SESSION_NOT_FOUND", message: "No active stream session", details: nil))
-        return
-      }
-
-      var didRespond = false
-      var listenerToken: AnyListenerToken?
-
-      listenerToken = streamSession.photoDataPublisher.listen { photoData in
-        guard !didRespond else { return }
-        didRespond = true
-        Task { await listenerToken?.cancel() }
-
-        let formatString: String = (photoData.format == .heic) ? "heic" : "jpeg"
-        let payload: [String: Any] = [
-          "bytes": FlutterStandardTypedData(bytes: photoData.data),
-          "format": formatString,
+    /// Creates a VTDecompressionSession for decoding HEVC frames to BGRA pixel buffers.
+    private func setupDecompressionSession(formatDescription: CMFormatDescription) {
+        let attrs: [String: Any] = [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
         ]
-        result(payload)
-      }
-
-      let accepted = streamSession.capturePhoto(format: captureFormat)
-      if !accepted, !didRespond {
-        didRespond = true
-        Task { await listenerToken?.cancel() }
-        result(FlutterError(code: "CAPTURE_NOT_READY", message: "Capture request was not accepted.", details: nil))
-      }
+        var session: VTDecompressionSession?
+        let status = VTDecompressionSessionCreate(
+            allocator: kCFAllocatorDefault,
+            formatDescription: formatDescription,
+            decoderSpecification: nil,
+            imageBufferAttributes: attrs as CFDictionary,
+            outputCallback: nil,
+            decompressionSessionOut: &session
+        )
+        if status == noErr, let session {
+            decompressionSession = session
+            NSLog("[MWDAT] Created VTDecompressionSession for HEVC decoding")
+        } else {
+            NSLog("[MWDAT] Failed to create VTDecompressionSession: \(status)")
+        }
     }
-  }
 
-  func getRegistrationState(result: @escaping FlutterResult) {
-    Task { @MainActor in
-      let state = Wearables.shared.registrationState
-      result(state.rawValue)
-    }
-  }
+    /// Decodes a compressed CMSampleBuffer (HEVC) to a CVPixelBuffer.
+    private func decodeCompressedFrame(_ sampleBuffer: CMSampleBuffer) -> CVPixelBuffer? {
+        guard let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer) else {
+            return nil
+        }
 
-  private static func parseStreamQuality(_ value: String?) -> StreamQuality {
-    switch value?.lowercased() {
-      case "high":
-        return .high
-      case "low":
-        return .low
-      case "medium":
-        return .medium
-      default:
-        return .high
-    }
-  }
+        // Lazily create decompression session on first frame
+        if decompressionSession == nil {
+            setupDecompressionSession(formatDescription: formatDescription)
+        }
 
-  private static func resolution(for quality: StreamQuality) -> StreamingResolution {
-    switch quality {
-      case .high:
-        return .high
-      case .low:
-        return .low
-      case .medium:
-        return .medium
+        guard let session = decompressionSession else {
+            return nil
+        }
+
+        var outputBuffer: CVPixelBuffer?
+        var flagOut: VTDecodeInfoFlags = []
+
+        let status = VTDecompressionSessionDecodeFrame(
+            session,
+            sampleBuffer: sampleBuffer,
+            flags: [], // synchronous decode
+            infoFlagsOut: &flagOut,
+            outputHandler: {
+                decodeStatus, _, imageBuffer, _, _ in
+                if decodeStatus == noErr {
+                    outputBuffer = imageBuffer
+                }
+            }
+        )
+
+        if status != noErr {
+            NSLog("[MWDAT] VTDecompressionSession decode error: \(status)")
+            return nil
+        }
+
+        return outputBuffer
     }
-  }
+
+    func setMockCameraFeed(call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any],
+              let uuidString = args["deviceUUID"] as? String
+        else {
+            result(FlutterError(code: "INVALID_ARGS", message: "deviceUUID missing", details: nil))
+            return
+        }
+
+        Task {
+            @MainActor in
+            let devices = MockDeviceKit.shared.pairedDevices
+            guard let device = devices.first(where: {
+                $0.deviceIdentifier == uuidString
+            }) else {
+                result(FlutterError(code: "DEVICE_NOT_FOUND", message: "No mock device with uuid \(uuidString)", details: nil))
+                return
+            }
+
+            guard let mockDisplaylessGlasses = device as? any MWDATMockDevice.MockDisplaylessGlasses else {
+                result(FlutterError(code: "INVALID_DEVICE_TYPE", message: "Device does not support camera", details: nil))
+                return
+            }
+
+            let cameraKit = mockDisplaylessGlasses.getCameraKit()
+
+            if let videoPath = args["videoPath"] as? String, !videoPath.isEmpty {
+                let fileURL = URL(fileURLWithPath: videoPath)
+
+                // Validate file exists
+                let fileManager = FileManager.default
+                if !fileManager.fileExists(atPath: videoPath) {
+                    result(FlutterError(code: "FILE_NOT_FOUND", message: "Video file not found at path: \(videoPath)", details: nil))
+                    return
+                }
+
+                // Validate video codec - must be HEVC/H.265
+                let asset = AVAsset(url: fileURL)
+                let tracks = try? await asset.loadTracks(withMediaType: .video)
+                var foundHEVC = false
+
+                if let videoTracks = tracks {
+                    for videoTrack in videoTracks {
+                        if let formatDescriptions = try? await videoTrack.load(.formatDescriptions) as? [CMFormatDescription],
+                           let formatDescription = formatDescriptions.first
+                        {
+                            let codecType = CMFormatDescriptionGetMediaSubType(formatDescription)
+                            let codecString = String(format: "%c%c%c%c",
+                                                     (codecType >> 24) & 0xFF,
+                                                     (codecType >> 16) & 0xFF,
+                                                     (codecType >> 8) & 0xFF,
+                                                     codecType & 0xFF)
+
+                            if codecType == kCMVideoCodecType_HEVC || codecString == "hvc1" || codecString == "hev1" {
+                                foundHEVC = true
+                                break
+                            }
+                        }
+                    }
+                }
+
+                if !foundHEVC {
+                    result(FlutterError(code: "INVALID_CODEC", message: "Video must be HEVC/H.265 format. Use file_picker (not image_picker) to preserve original format.", details: nil))
+                    return
+                }
+
+                await cameraKit.setCameraFeed(fileURL: fileURL)
+                result(true)
+            } else {
+                result(true)
+            }
+        }
+    }
+
+    func setMockCapturedImage(call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any],
+              let uuidString = args["deviceUUID"] as? String
+        else {
+            result(FlutterError(code: "INVALID_ARGS", message: "deviceUUID missing", details: nil))
+            return
+        }
+
+        Task {
+            @MainActor in
+            let devices = MockDeviceKit.shared.pairedDevices
+            guard let device = devices.first(where: {
+                $0.deviceIdentifier == uuidString
+            }) else {
+                result(FlutterError(code: "DEVICE_NOT_FOUND", message: "No mock device with uuid \(uuidString)", details: nil))
+                return
+            }
+
+            guard let mockDisplaylessGlasses = device as? any MWDATMockDevice.MockDisplaylessGlasses else {
+                result(FlutterError(code: "INVALID_DEVICE_TYPE", message: "Device does not support camera", details: nil))
+                return
+            }
+
+            let cameraKit = mockDisplaylessGlasses.getCameraKit()
+
+            if let imagePath = args["imagePath"] as? String, !imagePath.isEmpty {
+                let fileURL = URL(fileURLWithPath: imagePath)
+                await cameraKit.setCapturedImage(fileURL: fileURL)
+                result(true)
+            } else {
+                // If imagePath is nil or empty, we could clear the image or just return success
+                result(true)
+            }
+        }
+    }
+
+    func startStreamSession(call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any] else {
+            result(FlutterError(code: "INVALID_ARGS", message: "arguments missing", details: nil))
+            return
+        }
+
+        // Get FPS parameter (default to 30.0 if not provided)
+        let fps = (args["fps"] as? Double) ?? 30.0
+        let streamQuality = Self.parseStreamQuality(args["streamQuality"] as? String)
+        let videoCodecStr = args["videoCodec"] as? String ?? "raw"
+        let videoCodec: MWDATCamera.VideoCodec = (videoCodecStr == "hvc1") ? .hvc1 : .raw
+
+        // deviceUUID is optional - if not provided, use AutoDeviceSelector
+        let uuidString = args["deviceUUID"] as? String
+
+        Task {
+            @MainActor in
+            // Determine device selector
+            let deviceSelector: any DeviceSelector
+            if let uuidString = uuidString {
+                deviceSelector = SpecificDeviceSelector(device: uuidString)
+            } else {
+                deviceSelector = AutoDeviceSelector(wearables: Wearables.shared)
+            }
+
+            // Return existing texture if session is already active
+            if streamSession != nil {
+                if let texId = textureId {
+                    result(texId)
+                } else {
+                    result(FlutterError(code: "TEXTURE_ERROR", message: "Session exists but no texture registered", details: nil))
+                }
+                return
+            }
+
+            // Register a Flutter texture
+            guard let registry = textureRegistry else {
+                result(FlutterError(code: "TEXTURE_ERROR", message: "Texture registry not available", details: nil))
+                return
+            }
+            let texture = PixelBufferTexture()
+            let texId = registry.register(texture)
+            pixelBufferTexture = texture
+            textureId = texId
+            currentTargetFPS = fps
+            currentVideoCodec = videoCodec
+            frameCounter = 0
+            lastFrameSendTime = nil
+            NSLog("[MWDAT] Registered texture \(texId)")
+
+            // Create a new StreamSession
+            let fpsValue = UInt(max(1, Int(fps.rounded())))
+            let streamConfig = StreamSessionConfig(
+                videoCodec: videoCodec,
+                resolution: Self.resolution(for: streamQuality),
+                frameRate: fpsValue
+            )
+            let session = StreamSession(
+                streamSessionConfig: streamConfig,
+                deviceSelector: deviceSelector
+            )
+
+            // Observe errors
+            errorListenerToken = session.errorPublisher.listen {
+                error in
+                NSLog("[MWDAT] StreamSession error: \(error)")
+            }
+
+            // Store the session and connect event handlers
+            streamSession = session
+            streamStateHandler.session = session
+            streamErrorHandler.session = session
+
+            // Subscribe to video frames — push CVPixelBuffer directly, no encoding
+            videoListenerToken = session.videoFramePublisher.listen {
+                [weak self] videoFrame in
+                guard let self else {
+                    return
+                }
+                self.processAndSendFrame(videoFrame)
+            }
+
+            // Start the session
+            do {
+                await session.start()
+
+                if uuidString == nil, let activeDevice = deviceSelector.activeDevice {
+                    NSLog("[MWDAT] AutoDeviceSelector connected to device: \(activeDevice)")
+                }
+
+                result(texId)
+            } catch {
+                // Clean up on failure
+                await cleanupSession()
+                result(FlutterError(code: "STREAM_SESSION_ERROR", message: error.localizedDescription, details: nil))
+            }
+        }
+    }
+
+    func stopStreamSession(call _: FlutterMethodCall, result: @escaping FlutterResult) {
+        Task {
+            @MainActor in
+            guard streamSession != nil else {
+                result(FlutterError(code: "SESSION_NOT_FOUND", message: "No active stream session", details: nil))
+                return
+            }
+
+            await cleanupSession()
+            result(true)
+        }
+    }
+
+    func capturePhoto(call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let args = call.arguments as? [String: Any]
+        let formatStr = args?["format"] as? String ?? "jpeg"
+        let captureFormat: MWDATCamera.PhotoCaptureFormat = (formatStr == "heic") ? .heic : .jpeg
+
+        Task {
+            @MainActor in
+            guard let streamSession else {
+                result(FlutterError(code: "SESSION_NOT_FOUND", message: "No active stream session", details: nil))
+                return
+            }
+
+            var didRespond = false
+            var listenerToken: AnyListenerToken?
+
+            listenerToken = streamSession.photoDataPublisher.listen {
+                photoData in
+                guard !didRespond else {
+                    return
+                }
+                didRespond = true
+                Task {
+                    await listenerToken?.cancel()
+                }
+
+                let formatString: String = (photoData.format == .heic) ? "heic" : "jpeg"
+                let payload: [String: Any] = [
+                    "bytes": FlutterStandardTypedData(bytes: photoData.data),
+                    "format": formatString,
+                ]
+                result(payload)
+            }
+
+            let accepted = streamSession.capturePhoto(format: captureFormat)
+            if !accepted, !didRespond {
+                didRespond = true
+                Task {
+                    await listenerToken?.cancel()
+                }
+                result(FlutterError(code: "CAPTURE_NOT_READY", message: "Capture request was not accepted.", details: nil))
+            }
+        }
+    }
+
+    func captureStreamFrame(call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let args = call.arguments as? [String: Any]
+        let quality = (args?["quality"] as? Int) ?? 70
+
+        guard let texture = pixelBufferTexture,
+              let jpegData = texture.copyAsJpegData(quality: quality)
+        else {
+            result(nil)
+            return
+        }
+        result(FlutterStandardTypedData(bytes: jpegData))
+    }
+
+    func getRegistrationState(result: @escaping FlutterResult) {
+        Task {
+            @MainActor in
+            let state = Wearables.shared.registrationState
+            result(state.rawValue)
+        }
+    }
+
+    private static func parseStreamQuality(_ value: String?) -> StreamQuality {
+        switch value?.lowercased() {
+        case "high":
+            return .high
+        case "low":
+            return .low
+        case "medium":
+            return .medium
+        default:
+            return .high
+        }
+    }
+
+    private static func resolution(forquality _: StreamQuality) -> StreamingResolution {
+        switch quality {
+        case .high:
+            return .high
+        case .low:
+            return .low
+        case .medium:
+            return .medium
+        }
+    }
 }
 
 private enum StreamQuality {
-  case high
-  case medium
-  case low
+    case high
+    case medium
+    case low
 }

--- a/ios/Classes/PixelBufferTexture.swift
+++ b/ios/Classes/PixelBufferTexture.swift
@@ -4,31 +4,52 @@ import Flutter
 /// a new frame it calls `copyPixelBuffer()` which returns the latest buffer
 /// pushed from the native video-frame listener.
 class PixelBufferTexture: NSObject, FlutterTexture {
-  /// The latest pixel buffer to be rendered. Access is guarded by an
-  /// unfair lock so the video-frame callback (main actor) and the raster
-  /// thread (which calls `copyPixelBuffer`) never race.
-  private var _latestPixelBuffer: CVPixelBuffer?
-  private var lock = os_unfair_lock()
+    /// The latest pixel buffer to be rendered. Access is guarded by an
+    /// unfair lock so the video-frame callback (main actor) and the raster
+    /// thread (which calls `copyPixelBuffer`) never race.
+    private var _latestPixelBuffer: CVPixelBuffer?
+    private var lock = os_unfair_lock()
 
-  var latestPixelBuffer: CVPixelBuffer? {
-    get {
-      os_unfair_lock_lock(&lock)
-      let buf = _latestPixelBuffer
-      os_unfair_lock_unlock(&lock)
-      return buf
-    }
-    set {
-      os_unfair_lock_lock(&lock)
-      _latestPixelBuffer = newValue
-      os_unfair_lock_unlock(&lock)
-    }
-  }
+    private static let ciContext = CIContext()
 
-  func copyPixelBuffer() -> Unmanaged<CVPixelBuffer>? {
-    os_unfair_lock_lock(&lock)
-    let buf = _latestPixelBuffer
-    os_unfair_lock_unlock(&lock)
-    guard let buf else { return nil }
-    return Unmanaged.passRetained(buf)
-  }
+    var latestPixelBuffer: CVPixelBuffer? {
+        get {
+            os_unfair_lock_lock(&lock)
+            let buf = _latestPixelBuffer
+            os_unfair_lock_unlock(&lock)
+            return buf
+        }
+        set {
+            os_unfair_lock_lock(&lock)
+            _latestPixelBuffer = newValue
+            os_unfair_lock_unlock(&lock)
+        }
+    }
+
+    func copyPixelBuffer() -> Unmanaged<CVPixelBuffer>? {
+        os_unfair_lock_lock(&lock)
+        let buf = _latestPixelBuffer
+        os_unfair_lock_unlock(&lock)
+        guard let buf else {
+            return nil
+        }
+        return Unmanaged.passRetained(buf)
+    }
+
+    func copyAsJpegData(quality: Int = 70) -> Data? {
+        os_unfair_lock_lock(&lock)
+        let buf = _latestPixelBuffer
+        os_unfair_lock_unlock(&lock)
+        guard let buf else {
+            return nil
+        }
+        let ciImage = CIImage(cvPixelBuffer: buf)
+        let colorSpace = ciImage.colorSpace ?? CGColorSpaceCreateDeviceRGB()
+        let normalised = Float(min(max(quality, 1), 100)) / 100.0
+        let options: [CIImageRepresentationOption: Any] = [
+            kCGImageDestinationLossyCompressionQuality as CIImageRepresentationOption: normalised,
+        ]
+
+        return Self.ciContext.jpegRepresentation(of: ciImage, colorSpace: colorSpace, options: options)
+    }
 }

--- a/lib/flutter_meta_wearables_dat.dart
+++ b/lib/flutter_meta_wearables_dat.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:typed_data';
-import 'dart:ui' as ui;
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter_meta_wearables_dat/meta_wearables_dat_platform_interface.dart';
@@ -141,22 +140,6 @@ enum PhotoCaptureFormat {
   final String value;
 }
 
-/// Supported pixel formats for captured stream frames.
-///
-/// These map to Flutter's [ui.ImageByteFormat] values internally.
-enum FrameFormat {
-  /// Raw RGBA pixel data (4 bytes per pixel, pre-multiplied alpha).
-  /// Best for ML inference and image processing pipelines.
-  rawRgba,
-
-  /// Raw RGBA pixel data with straight (non-pre-multiplied) alpha.
-  rawStraightRgba,
-
-  /// PNG-encoded image data.
-  /// Larger than raw formats but widely compatible.
-  png,
-}
-
 /// Exception thrown when a camera permission request fails.
 class CameraPermissionException implements Exception {
   /// The error code from the native SDK.
@@ -200,38 +183,6 @@ class CapturedPhoto {
   String get fileExtension => format == 'heic' ? 'heic' : 'jpg';
 
   String get mimeType => format == 'heic' ? 'image/heic' : 'image/jpeg';
-}
-
-/// A single video frame captured from an active stream session's Flutter
-/// texture.
-///
-/// [CapturedFrame] is captured silently on the Dart side by rasterizing the
-/// Flutter texture. The pixel data is suitable for OCR, ML inference, or any
-/// image processing that needs raw frame access.
-class CapturedFrame {
-  /// The raw pixel data of the captured frame.
-  ///
-  /// The encoding depends on the [format] used during capture:
-  /// - [FrameFormat.rawRgba] / [FrameFormat.rawStraightRgba]: 4 bytes per
-  ///   pixel (R, G, B, A), total size = [width] * [height] * 4.
-  /// - [FrameFormat.png]: PNG-encoded image data.
-  final Uint8List bytes;
-
-  /// The width of the captured frame in pixels.
-  final int width;
-
-  /// The height of the captured frame in pixels.
-  final int height;
-
-  /// The pixel format of [bytes].
-  final FrameFormat format;
-
-  const CapturedFrame({
-    required this.bytes,
-    required this.width,
-    required this.height,
-    required this.format,
-  });
 }
 
 /// The main class for the Meta Wearables DAT.
@@ -324,6 +275,10 @@ class MetaWearablesDat {
   /// Returns a texture ID for rendering via the Flutter `Texture` widget.
   /// Video frames are pushed directly from native to the GPU — no encoding,
   /// no byte copying, no Dart-side decoding.
+  ///
+  /// Note: These frames do not update when your app is backgrounded.
+  /// Use [captureStreamFrame] to get JPEG-encoded frame data that works
+  /// in both foreground and background.
   static Future<int> startStreamSession(
     String? deviceUUID, {
     double fps = 30.0,
@@ -360,60 +315,32 @@ class MetaWearablesDat {
     );
   }
 
-  /// Captures a single frame from an active stream session's Flutter texture.
+  /// Captures a single JPEG-encoded frame from the active stream session.
   ///
-  /// This is a **Dart-side** operation that rasterizes the texture identified
-  /// by [textureId] (returned by [startStreamSession]) into pixel data.
-  /// No native code is invoked and the capture is near-instantaneous.
+  /// Reads the latest pixel buffer directly from native memory and encodes
+  /// it as JPEG. Unlike the Flutter `Texture` widget, the native pixel
+  /// buffer remains accessible across background/foreground transitions.
   ///
-  /// Use this when you need raw frame bytes for OCR, ML inference, computer
-  /// vision, or any processing that requires direct pixel access.
+  /// [quality] controls JPEG compression (1–100). Lower values produce
+  /// smaller files at the cost of image fidelity. Defaults to 70.
   ///
-  /// **Note:** Raw RGBA at the default 720x1280 resolution is ~3.7 MB per
-  /// frame. This method is intended for on-demand captures (e.g., every
-  /// 200-500 ms), not continuous per-frame processing.
+  /// Returns a `Uint8List` containing JPEG image data suitable for network
+  /// transmission, on-device ML inference, or display via `Image.memory()`.
   ///
-  /// Returns a [CapturedFrame] containing the pixel data, or `null` if the
-  /// capture failed (e.g., texture not available).
-  static Future<CapturedFrame?> captureStreamFrame(
-    int textureId, {
-    int width = 720,
-    int height = 1280,
-    FrameFormat format = FrameFormat.rawRgba,
-  }) async {
-    final builder = ui.SceneBuilder()
-      ..addTexture(
-        textureId,
-        width: width.toDouble(),
-        height: height.toDouble(),
-        freeze: true,
-        filterQuality: ui.FilterQuality.high,
+  /// Returns `null` if no stream session is active or no frame is available.
+  ///
+  /// Throws [ArgumentError] if [quality] is outside the 1–100 range.
+  static Future<Uint8List?> captureStreamFrame({int quality = 70}) {
+    if (quality < 1 || quality > 100) {
+      throw ArgumentError.value(
+        quality,
+        'quality',
+        'Must be between 1 and 100',
       );
-    final scene = builder.build();
-    try {
-      final image = await scene.toImage(width, height);
-      try {
-        final imageByteFormat = switch (format) {
-          FrameFormat.rawRgba => ui.ImageByteFormat.rawRgba,
-          FrameFormat.rawStraightRgba => ui.ImageByteFormat.rawStraightRgba,
-          FrameFormat.png => ui.ImageByteFormat.png,
-        };
-        final byteData = await image.toByteData(
-          format: imageByteFormat,
-        );
-        if (byteData == null) return null;
-        return CapturedFrame(
-          bytes: byteData.buffer.asUint8List(),
-          width: width,
-          height: height,
-          format: format,
-        );
-      } finally {
-        image.dispose();
-      }
-    } finally {
-      scene.dispose();
     }
+    return MetaWearablesDatPlatform.instance.captureStreamFrame(
+      quality: quality,
+    );
   }
 
   /// Stream of stream session state changes.
@@ -436,16 +363,16 @@ class MetaWearablesDat {
 
   /// Gets the current registration state.
   static Future<RegistrationState> getRegistrationState() async {
-    final registrationState = await MetaWearablesDatPlatform.instance
-        .getRegistrationState();
+    final registrationState =
+        await MetaWearablesDatPlatform.instance.getRegistrationState();
     debugPrint('[MetaWearablesDAT] Registration state: $registrationState');
     return registrationState;
   }
 
   /// Stream of registration state changes.
   static Stream<RegistrationState> registrationStateStream() {
-    final registrationStateStream = MetaWearablesDatPlatform.instance
-        .registrationStateStream();
+    final registrationStateStream =
+        MetaWearablesDatPlatform.instance.registrationStateStream();
     return registrationStateStream;
   }
 

--- a/lib/meta_wearables_dat_method_channel.dart
+++ b/lib/meta_wearables_dat_method_channel.dart
@@ -262,15 +262,15 @@ class MethodChannelMetaWearablesDat extends MetaWearablesDatPlatform {
   @override
   Stream<RegistrationState> registrationStateStream() {
     return eventChannel.receiveBroadcastStream().map(
-      (dynamic event) => RegistrationState.fromInt(event as int),
-    );
+          (dynamic event) => RegistrationState.fromInt(event as int),
+        );
   }
 
   @override
   Stream<StreamSessionState> streamSessionStateStream() {
     return streamSessionStateEventChannel.receiveBroadcastStream().map(
-      (dynamic event) => StreamSessionState.fromInt(event as int),
-    );
+          (dynamic event) => StreamSessionState.fromInt(event as int),
+        );
   }
 
   @override
@@ -289,8 +289,8 @@ class MethodChannelMetaWearablesDat extends MetaWearablesDatPlatform {
   @override
   Stream<bool> activeDeviceStream() {
     return activeDeviceEventChannel.receiveBroadcastStream().map(
-      (dynamic event) => event as bool,
-    );
+          (dynamic event) => event as bool,
+        );
   }
 
   @override
@@ -299,5 +299,15 @@ class MethodChannelMetaWearablesDat extends MetaWearablesDatPlatform {
       'restartActiveDeviceMonitoring',
     );
     return ok ?? false;
+  }
+
+  @override
+  Future<Uint8List?> captureStreamFrame({int quality = 70}) async {
+    final bytes = await methodChannel.invokeMethod<Uint8List>(
+      'captureStreamFrame',
+      {'quality': quality},
+    );
+
+    return bytes;
   }
 }

--- a/lib/meta_wearables_dat_platform_interface.dart
+++ b/lib/meta_wearables_dat_platform_interface.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: public_member_api_docs
 
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter_meta_wearables_dat/flutter_meta_wearables_dat.dart';
 import 'package:flutter_meta_wearables_dat/meta_wearables_dat_method_channel.dart';
@@ -148,6 +149,12 @@ abstract class MetaWearablesDatPlatform extends PlatformInterface {
   Future<bool> restartActiveDeviceMonitoring() {
     throw UnimplementedError(
       'restartActiveDeviceMonitoring() has not been implemented.',
+    );
+  }
+
+  Future<Uint8List?> captureStreamFrame({int quality = 70}) {
+    throw UnimplementedError(
+      'captureStreamFrame() has not been implemented.',
     );
   }
 }


### PR DESCRIPTION
# Pull Request

## Breaking Changes

- Reworked captureStreamFrame API — The method now returns Future<Uint8List?> (JPEG bytes) instead of Future<CapturedFrame?>, reading latest pixel buffer from memory instead of from a flutter texture.
- Removed CapturedFrame class — Replaced by raw Uint8List JPEG data.
- Removed FrameFormat enum — No longer needed since output is always JPEG.

## New Features

- Native JPEG frame capture — captureStreamFrame() now pulls the latest frame from the native pixel buffer and encodes it as JPEG on the native side (iOS via CIContext.jpegRepresentation, Android via Bitmap.compress). This works independently of the Flutter texture lifecycle, enabling background processing when the app is not in the foreground.
- Configurable JPEG quality — New quality parameter (1–100, default 70) controls compression. Validated with ArgumentError on the Dart side.

## Misc

- MetaWearablesDatPlugin.kt changed a lot because of a lack of formatting. I recommend we run a lint pre commit on any changes.
- This works really well for iOS only with .hvc1 VideoCodec as documented by Meta.
- [] Test Android behaviour with configured background modes in Manfiest.
- [] Document iOS changes needed outside of using .hvc1
- [] Update Example app to showcase it.