### PR TITLE
Audit codebase + apply improvements

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -38,3 +38,8 @@ example/android/.gradle/
 example/android/build/
 example/android/app/build/
 example/android/local.properties
+
+# Secrets used by the example app — git-ignored, but pub respects .pubignore
+# over .gitignore, so list them explicitly to keep them out of the archive.
+example/android/secrets.properties
+example/ios/Flutter/Secrets.xcconfig

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -421,7 +421,7 @@ Codec payload layout:
 
 | Codec | iOS | Android |
 |-------|-----|---------|
-| `raw` | BGRA, `width * height * 4` bytes | I420 planar YUV, `width * height * 3/2` bytes |
+| `raw` | BGRA, `bytesPerRow * height` bytes (rows may be padded — use `VideoFrame.bytesPerRow`) | I420 planar YUV, `width * height * 3/2` bytes (tightly packed; `bytesPerRow` is `null`) |
 | `hvc1` | raw HEVC NAL units (self-contained: keyframes carry VPS/SPS/PPS) | n/a — Android SDK doesn't support `hvc1` |
 
 `videoFramesStream()` is zero-cost when no subscriber is attached. Subscribe **before** `startStreamSession()` to capture the opening keyframe.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.5.1
+* Future-proof Android Gradle scripts for Flutter's [Built-in Kotlin migration](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors). The Kotlin Gradle Plugin is now applied conditionally (`if (agpMajor < 9)`) — once a consumer upgrades to AGP 9, KGP will be auto-injected by Flutter's tooling and this plugin will stop contributing to the `Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP)` warning. On AGP < 9 (current Flutter 3.44 baseline) nothing changes: KGP is still applied so the plugin continues to compile, and the warning continues to fire from this and other plugins in the same situation until the host app moves to AGP 9.
+* Replace the deprecated `android.kotlinOptions { }` block with the modern top-level `kotlin.compilerOptions { }` DSL.
+* **Android** `requestCameraPermission`: stop collapsing `RequestPermissionContract.parseResult` failures (`NO_DEVICE`, `REQUEST_TIMEOUT`, `CONNECTION_ERROR`, …) to `PermissionStatus.Denied`. Those now surface through `mapPermissionError` as typed `CameraPermissionException`s (`DEVICE_DISCONNECTED` / `INTERNAL_ERROR`), matching the contract the Dart side already documents — `false` means *user explicitly denied*, not "something went wrong".
+* **iOS** `getCameraPermissionStatus`: stop swallowing every `MWDATCore.PermissionError` as `false`. The status check now routes through the same `mapPermissionError` helper as `requestCameraPermission`, so no-device / Meta-AI-missing / timeout cases are reported identically across iOS and Android.
+* Gate `debugPrint` calls in the event-stream pipelines (`registrationState`, `streamSessionState`, `streamSessionError`, `activeDevice`, `videoStreamSize`, `deviceState`) behind `kDebugMode`. Flutter's `debugPrint` is *not* automatically a no-op in release builds, so previously consumers' release apps were emitting per-event plugin logs they had no way to silence.
+* No API changes; consumers do not need to change anything beyond bumping the dependency.
+
 ## 0.5.0
 * Update to DAT SDK 0.7.0 on iOS and Android. Existing Dart APIs unchanged; new opt-in additions below — non-breaking, drop-in upgrade.
 * New `openDATGlassesAppUpdate()` — opens the Meta AI app to update the on-device DAT app. Pair with the new `datAppOnTheGlassesUpdateRequired` error code to drive a "tap to update" UI.

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ final sub = MetaWearablesDat.videoFramesStream().listen((frame) {
 
 Frame bytes are codec-dependent:
 
-- `VideoCodec.raw` — **iOS**: BGRA pixel data, tightly packed at `width * height * 4` bytes. **Android**: I420 planar YUV at `width * height * 3/2` bytes (Y plane, then U, then V).
+- `VideoCodec.raw` — **iOS**: BGRA pixel data at `bytesPerRow * height` bytes; rows may carry trailing padding for alignment, so iterate rows with `VideoFrame.bytesPerRow` rather than assuming `width * 4`. **Android**: I420 planar YUV, tightly packed at `width * height * 3/2` bytes (Y plane, then U, then V; `bytesPerRow` is `null`).
 - `VideoCodec.hvc1` (iOS only) — raw HEVC elementary stream (`hvc1` NAL units). Keyframes carry the parameter sets (VPS/SPS/PPS) inline, so the stream is self-contained and can be fed straight into `ffmpeg -i file.h265 out.mp4` or muxed into an mp4 track via `ffmpeg_kit_flutter`.
 
 Subscribing to `videoFramesStream()` is zero-cost when there are no listeners — the plugin won't encode or emit anything until the first subscriber attaches. Always subscribe *before* calling `startStreamSession()` if you want to capture the opening keyframe.

--- a/agent/claude/skills/camera-streaming.md
+++ b/agent/claude/skills/camera-streaming.md
@@ -86,7 +86,7 @@ Payload layout:
 
 | Codec | iOS bytes | Android bytes |
 |-------|-----------|---------------|
-| `raw` | BGRA, `width * height * 4` | I420 planar YUV, `width * height * 3/2` |
+| `raw` | BGRA, `bytesPerRow * height` (use `VideoFrame.bytesPerRow` — rows may be padded) | I420 planar YUV, `width * height * 3/2` (tightly packed; `bytesPerRow` is `null`) |
 | `hvc1` | HEVC NAL units (self-contained: keyframes carry VPS/SPS/PPS) | n/a |
 
 `videoFramesStream()` is zero-cost when no subscriber is attached. Subscribe **before** `startStreamSession()` to capture the opening keyframe. `captureStreamFrame` still returns `null` while backgrounded — use `videoFramesStream()` for pixel data in background.

--- a/agent/claude/skills/permissions.md
+++ b/agent/claude/skills/permissions.md
@@ -30,14 +30,18 @@ if (!hasPermission) {
   // User can: allow always, allow once, or deny
   try {
     final granted = await MetaWearablesDat.requestCameraPermission();
+    if (!granted) {
+      // User declined the prompt — SDK returns false (not an exception).
+    }
   } on CameraPermissionException catch (e) {
     if (e.isDeviceDisconnected) {
-      // Device is disconnected or powered off
-    } else if (e.isPermissionDenied) {
-      // User denied permission
+      // No Ray-Ban Meta reachable (powered off, out of range, no connection).
     } else if (e.isInternalError) {
-      // Internal SDK error
+      // SDK-side failure: request already in progress, timeout,
+      // Meta AI app missing, generic internal error.
     }
+    // isPermissionDenied is reserved for future SDK semantics — current
+    // SDK surfaces user denial as `granted == false` above, not here.
   }
 }
 ```
@@ -49,9 +53,9 @@ if (!hasPermission) {
 | `code` | Error code string |
 | `message` | Human-readable description |
 | `details` | Additional error details (Map) |
-| `isDeviceDisconnected` | Device is disconnected or powered off |
-| `isPermissionDenied` | User denied permission |
-| `isInternalError` | Internal SDK error |
+| `isDeviceDisconnected` | No Ray-Ban Meta reachable (powered off, out of range, no connection) |
+| `isPermissionDenied` | Reserved for future SDK semantics — user denial currently returns `false` from `requestCameraPermission()`, not an exception |
+| `isInternalError` | Request already in progress, timeout, Meta AI app missing, or any other SDK-side failure |
 
 ## Order matters
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,16 @@ allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+// Flutter is moving to "Built-in Kotlin" with AGP 9 (Flutter 3.44+); applying
+// the Kotlin Gradle Plugin there both triggers a deprecation warning and will
+// fail the build in a future Flutter release. Apply KGP only on the legacy
+// path; on AGP 9+, AGP injects Kotlin support itself.
+// https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: "kotlin-android"
+}
 
 android {
     namespace = "io.rodcone.flutter_meta_wearables_dat"
@@ -34,10 +43,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
     }
 
     sourceSets {
@@ -70,5 +75,11 @@ android {
                showStandardStreams = true
             }
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }

--- a/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
+++ b/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
@@ -19,6 +19,7 @@ import com.meta.wearable.dat.core.selectors.AutoDeviceSelector
 import com.meta.wearable.dat.core.selectors.DeviceSelector
 import com.meta.wearable.dat.core.session.DeviceSessionState
 import com.meta.wearable.dat.core.session.DeviceSession
+import com.meta.wearable.dat.core.types.DatResult
 import com.meta.wearable.dat.core.types.Permission
 import com.meta.wearable.dat.core.types.PermissionError
 import com.meta.wearable.dat.core.types.PermissionStatus
@@ -108,7 +109,8 @@ class MetaWearablesDatPlugin :
     private var btPermissionsGranted = false
 
     // Permission request handling
-    private var permissionContinuation: CancellableContinuation<PermissionStatus>? = null
+    private var permissionContinuation:
+        CancellableContinuation<DatResult<PermissionStatus, PermissionError>>? = null
     private val permissionMutex = Mutex()
     // Lazy so it isn't constructed at plugin load — the 0.6.0 SDK types
     // may touch `Wearables` internals and throw before `Wearables.initialize()`.
@@ -333,9 +335,13 @@ class MetaWearablesDatPlugin :
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
         if (requestCode != PERMISSION_REQUEST_CODE) return false
-        val status = permissionContract.parseResult(resultCode, data)
-        val permissionStatus = status.getOrDefault(PermissionStatus.Denied)
-        permissionContinuation?.resume(permissionStatus)
+        // Carry the full DatResult through so the caller can distinguish a
+        // user-initiated denial (PermissionStatus.Denied) from a contract
+        // failure (NO_DEVICE, REQUEST_TIMEOUT, …). Collapsing both to
+        // PermissionStatus.Denied here would silently lie to the Dart layer,
+        // which now treats `false` as "user denied" exclusively.
+        val parseResult = permissionContract.parseResult(resultCode, data)
+        permissionContinuation?.resume(parseResult)
         permissionContinuation = null
         return true
     }
@@ -516,14 +522,33 @@ class MetaWearablesDatPlugin :
                         return@withLock
                     }
 
-                    val permissionStatus =
-                            suspendCancellableCoroutine<PermissionStatus> { continuation ->
+                    val parseResult =
+                            suspendCancellableCoroutine<
+                                DatResult<PermissionStatus, PermissionError>
+                            > { continuation ->
                                 permissionContinuation = continuation
                                 continuation.invokeOnCancellation { permissionContinuation = null }
                                 val intent = permissionContract.createIntent(act, Permission.CAMERA)
                                 act.startActivityForResult(intent, PERMISSION_REQUEST_CODE)
                             }
 
+                    // Mirror checkCameraPermissionStatus: contract failures
+                    // (NO_DEVICE, REQUEST_TIMEOUT, …) become typed errors via
+                    // mapPermissionError; only an explicit PermissionStatus.Denied
+                    // result returns `false` to the Dart layer.
+                    var failure: PermissionError? = null
+                    parseResult.onFailure { error, _ -> failure = error }
+                    val err = failure
+                    if (err != null) {
+                        result.error(
+                                mapPermissionError(err),
+                                err.description,
+                                mapOf("errorType" to err.name),
+                        )
+                        return@withLock
+                    }
+                    val permissionStatus =
+                            parseResult.getOrNull() ?: PermissionStatus.Denied
                     result.success(permissionStatus == PermissionStatus.Granted)
                 } catch (e: Exception) {
                     result.error(

--- a/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
+++ b/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
@@ -20,6 +20,7 @@ import com.meta.wearable.dat.core.selectors.DeviceSelector
 import com.meta.wearable.dat.core.session.DeviceSessionState
 import com.meta.wearable.dat.core.session.DeviceSession
 import com.meta.wearable.dat.core.types.Permission
+import com.meta.wearable.dat.core.types.PermissionError
 import com.meta.wearable.dat.core.types.PermissionStatus
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
@@ -448,7 +449,7 @@ class MetaWearablesDatPlugin :
                 result.success(status == PermissionStatus.Granted)
             } catch (e: Exception) {
                 result.error(
-                        "PERMISSION_ERROR",
+                        "INTERNAL_ERROR",
                         e.message ?: "Failed to check camera permission status.",
                         null
                 )
@@ -458,13 +459,35 @@ class MetaWearablesDatPlugin :
 
     private suspend fun checkCameraPermissionStatus(result: Result): PermissionStatus? {
         val checkResult = Wearables.checkPermissionStatus(Permission.CAMERA)
-        var permissionErrorMessage: String? = null
-        checkResult.onFailure { error, _ -> permissionErrorMessage = error.description }
-        if (permissionErrorMessage != null) {
-            result.error("PERMISSION_ERROR", permissionErrorMessage, null)
+        var failure: PermissionError? = null
+        checkResult.onFailure { error, _ -> failure = error }
+        val err = failure
+        if (err != null) {
+            result.error(
+                    mapPermissionError(err),
+                    err.description,
+                    mapOf("errorType" to err.name),
+            )
             return null
         }
         return checkResult.getOrNull() ?: PermissionStatus.Denied
+    }
+
+    /**
+     * Map an SDK [PermissionError] to one of the typed codes that
+     * `CameraPermissionException` predicates on the Dart side. `PERMISSION_DENIED`
+     * is reserved for the case where a user explicitly declines the request — the
+     * SDK doesn't surface that as an error (it returns `PermissionStatus.Denied`),
+     * so it's never emitted here.
+     */
+    private fun mapPermissionError(error: PermissionError): String = when (error) {
+        PermissionError.NO_DEVICE,
+        PermissionError.NO_DEVICE_WITH_CONNECTION,
+        PermissionError.CONNECTION_ERROR -> "DEVICE_DISCONNECTED"
+        PermissionError.META_AI_NOT_INSTALLED,
+        PermissionError.REQUEST_IN_PROGRESS,
+        PermissionError.REQUEST_TIMEOUT,
+        PermissionError.INTERNAL_ERROR -> "INTERNAL_ERROR"
     }
 
     /**
@@ -486,7 +509,7 @@ class MetaWearablesDatPlugin :
                     val act = activity
                     if (act == null) {
                         result.error(
-                                "PERMISSION_ERROR",
+                                "INTERNAL_ERROR",
                                 "Activity is not available. Ensure the app is in the foreground.",
                                 null
                         )
@@ -504,7 +527,7 @@ class MetaWearablesDatPlugin :
                     result.success(permissionStatus == PermissionStatus.Granted)
                 } catch (e: Exception) {
                     result.error(
-                            "PERMISSION_ERROR",
+                            "INTERNAL_ERROR",
                             e.message ?: "Failed to request permission.",
                             null
                     )

--- a/doc/MAINTAINERS.md
+++ b/doc/MAINTAINERS.md
@@ -75,10 +75,10 @@ Update the version in **both** `build.gradle` files (each plugin owns its own `e
 
 ```groovy
 // android/build.gradle (core)
-ext.mwdat_version = "0.6.0"  // mwdat-core, mwdat-camera
+ext.mwdat_version = "0.7.0"  // mwdat-core, mwdat-camera
 
 // flutter_meta_wearables_dat_mock_device/android/build.gradle
-ext.mwdat_version = "0.6.0"  // mwdat-mockdevice
+ext.mwdat_version = "0.7.0"  // mwdat-mockdevice
 ```
 
 Keep the two values in sync — mixing versions across the two plugins risks ABI breakage at runtime.
@@ -99,8 +99,12 @@ Key Android-specific implementation files:
 - `FrameProcessor.kt` — I420→ARGB frame conversion and FPS throttling
 - `ActiveDeviceStreamHandler.kt` — active device event channel
 - `RegistrationStateStreamHandler.kt` — registration state event channel
-- `StreamSessionStateStreamHandler.kt` — stream session state event channel (maps `StreamSessionState` enum to int)
-- `StreamSessionErrorStreamHandler.kt` — stream session error event channel (programmable sink, Android SDK has no native error publisher)
+- `StreamStateStreamHandler.kt` — stream state event channel (maps DAT 0.7.0 `StreamState` enum to int; Dart-facing channel name stays `stream_session_state` for backwards compat)
+- `StreamSessionErrorStreamHandler.kt` — stream session error event channel. Funnels three sources: `Stream.errorStream` (`StreamError`), `DeviceSession.errors` (`DeviceSessionError`, since DAT 0.7.0), and pre-stream `sendError(code, message)` calls
+- `DeviceStateStreamHandler.kt` — per-device thermal state stream (switches its inner subscription when `AutoDeviceSelector` swaps the active device)
+- `VideoFrameStreamHandler.kt` — per-frame I420 byte forwarder for `video_frames` event channel
+- `VideoStreamSizeStreamHandler.kt` — emits `{width, height}` on stream start and resolution changes
+- `BackgroundStreamingService.kt` — foreground service (`connectedDevice` type, API 30+) + wake lock for background streaming
 
 ### 5. Test Build
 

--- a/doc/android/Documentation.md
+++ b/doc/android/Documentation.md
@@ -2,9 +2,9 @@ This documentation folder contains the `CameraAccess` Android sample (Kotlin) fr
 
 To keep the repository lightweight, the Android sample app is excluded via .gitignore. If needed, you can clone it directly from `https://github.com/facebook/meta-wearables-dat-android/tree/main/samples/CameraAccess`.
 
-## Key SDK types (Android DAT 0.6.0)
+## Key SDK types (Android DAT 0.7.0)
 
-### StreamSessionState enum
+### StreamState enum (renamed from `StreamSessionState` in 0.7.0)
 - `STARTING` — session is starting
 - `STARTED` — session has started (pre-streaming)
 - `STREAMING` — actively streaming video frames
@@ -27,8 +27,8 @@ To keep the repository lightweight, the Android sample app is excluded via .giti
 | Feature | iOS | Android |
 |---------|-----|---------|
 | Video codec selection | `raw` and `hvc1` | `raw` only (I420) |
-| Background streaming | Yes (with `hvc1`) | No |
-| Error publisher | `session.errorPublisher` flow | No native error flow |
+| Background streaming | Yes (with `hvc1`) — `AVAudioSession` keep-alive | Yes — foreground service (`connectedDevice` type, API 30+) + `PARTIAL_WAKE_LOCK` |
+| Error publisher | `MWDATCamera.Stream.errorStream` + `DeviceSession.errors` (since DAT 0.7.0) | `Stream.errorStream` (`StreamError`) + `DeviceSession.errors` (`DeviceSessionError`, since DAT 0.7.0) |
 | Session states | stopping, stopped, waitingForDevice, starting, streaming, paused | STARTING, STARTED, STREAMING, STOPPING, STOPPED, CLOSED |
 | Photo format param | Selectable (HEIC/JPEG) | Device-determined |
 | Photo capture result | `AnyListenerToken` pattern | `DatResult<PhotoData, CaptureError>` |

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -43,9 +43,6 @@ PODS:
     - flutter_meta_wearables_dat
   - image_picker_ios (0.0.1):
     - Flutter
-  - path_provider_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
   - SDWebImage (5.21.7):
     - SDWebImage/Core (= 5.21.7)
   - SDWebImage/Core (5.21.7)
@@ -60,7 +57,6 @@ DEPENDENCIES:
   - flutter_meta_wearables_dat (from `.symlinks/plugins/flutter_meta_wearables_dat/ios`)
   - flutter_meta_wearables_dat_mock_device (from `.symlinks/plugins/flutter_meta_wearables_dat_mock_device/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
-  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
 
 SPEC REPOS:
@@ -83,8 +79,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_meta_wearables_dat_mock_device/ios"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
-  path_provider_foundation:
-    :path: ".symlinks/plugins/path_provider_foundation/darwin"
   share_plus:
     :path: ".symlinks/plugins/share_plus/ios"
 
@@ -94,10 +88,9 @@ SPEC CHECKSUMS:
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
   file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_meta_wearables_dat: 5a40beb8f4443e8ab2025114269f5caa9c4263fd
-  flutter_meta_wearables_dat_mock_device: 62dc282778ac40860e0c703ef0f5d806f832aa08
+  flutter_meta_wearables_dat: 636413eceaeaf2818a6140323167b4d69df99f92
+  flutter_meta_wearables_dat_mock_device: 81dbcc002ad8188b086975382973bd2edf0a5243
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
-  path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				31E12E9BD0748A0DEE0D6260 /* [CP] Embed Pods Frameworks */,
+				2E8C0E05E06F43941C4322CF /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -281,6 +282,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		2E8C0E05E06F43941C4322CF /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		31E12E9BD0748A0DEE0D6260 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -33,14 +33,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  args:
+    dependency: transitive
+    description:
+      name: args
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -65,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  code_assets:
+    dependency: transitive
+    description:
+      name: code_assets
+      sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   collection:
     dependency: transitive
     description:
@@ -77,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "942a4791cd385a68ccb3b32c71c427aba508a1bb949b86dff2adbe4049f16239"
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5"
+    version: "0.3.5+2"
   crypto:
     dependency: transitive
     description:
@@ -93,10 +109,10 @@ packages:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
+      sha256: "41e005c33bd814be4d3096aff55b1908d419fde52ca656c8c47719ec745873cd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.8"
+    version: "1.0.9"
   fake_async:
     dependency: transitive
     description:
@@ -109,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   file:
     dependency: transitive
     description:
@@ -133,34 +149,34 @@ packages:
     dependency: transitive
     description:
       name: file_selector_linux
-      sha256: "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33"
+      sha256: "2567f398e06ac72dcf2e98a0c95df2a9edd03c2c2e0cacd4780f20cdf56263a0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.3+2"
+    version: "0.9.4"
   file_selector_macos:
     dependency: transitive
     description:
       name: file_selector_macos
-      sha256: "88707a3bec4b988aaed3b4df5d7441ee4e987f20b286cddca5d6a8270cab23f2"
+      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.4+5"
+    version: "0.9.5"
   file_selector_platform_interface:
     dependency: transitive
     description:
       name: file_selector_platform_interface
-      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
+      sha256: "35e0bd61ebcdb91a3505813b055b09b79dfdc7d0aee9c09a7ba59ae4bb13dc85"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.2"
+    version: "2.7.0"
   file_selector_windows:
     dependency: transitive
     description:
       name: file_selector_windows
-      sha256: "320fcfb6f33caa90f0b58380489fc5ac05d99ee94b61aa96ec2bff0ba81d3c2b"
+      sha256: "62197474ae75893a62df75939c777763d39c2bc5f73ce5b88497208bc269abfd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.3+4"
+    version: "0.9.3+5"
   fixnum:
     dependency: transitive
     description:
@@ -200,10 +216,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "306f0596590e077338312f38837f595c04f28d6cdeeac392d3d74df2f0003687"
+      sha256: "38d1c268de9097ff59cf0e844ac38759fc78f76836d37edad06fa21e182055a0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.32"
+    version: "2.0.34"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -218,18 +234,26 @@ packages:
     dependency: transitive
     description:
       name: gtk
-      sha256: e8ce9ca4b1df106e4d72dad201d345ea1a036cc12c360f1a7d5a758f78ffa42c
+      sha256: "4ff85b2a16724029dd9e5bbb5a94b6918f9973f74ba571c949d2002801879cf5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
+  hooks:
+    dependency: transitive
+    description:
+      name: hooks
+      sha256: a41af4e8fc687cd6d33de9751eb936c8c0204ebe2bcb6c15ecf707504bf47f31
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.0"
   http_parser:
     dependency: transitive
     description:
@@ -242,34 +266,34 @@ packages:
     dependency: "direct main"
     description:
       name: image_picker
-      sha256: "736eb56a911cf24d1859315ad09ddec0b66104bc41a7f8c5b96b4e2620cf5041"
+      sha256: "91c025426c2881c551100bce834e201c835a170151545f58d17da5180ca7d9ac"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.2"
   image_picker_android:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: ca2a3b04d34e76157e9ae680ef16014fb4c2d20484e78417eaed6139330056f6
+      sha256: d5b3e1774af29c9ab00103afb0d4614070f924d2e0057ac867ec98800114793f
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.13+7"
+    version: "0.8.13+17"
   image_picker_for_web:
     dependency: transitive
     description:
       name: image_picker_for_web
-      sha256: "40c2a6a0da15556dc0f8e38a3246064a971a9f512386c3339b89f76db87269b6"
+      sha256: "66257a3191ab360d23a55c8241c91a6e329d31e94efa7be9cf7a212e65850214"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   image_picker_ios:
     dependency: transitive
     description:
       name: image_picker_ios
-      sha256: e675c22790bcc24e9abd455deead2b7a88de4b79f7327a281812f14de1a56f58
+      sha256: b9c4a438a9ff4f60808c9cf0039b93a42bb6c2211ef6ebb647394b2b3fa84588
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.13+1"
+    version: "0.8.13+6"
   image_picker_linux:
     dependency: transitive
     description:
@@ -302,6 +326,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
+  jni:
+    dependency: transitive
+    description:
+      name: jni
+      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  jni_flutter:
+    dependency: transitive
+    description:
+      name: jni_flutter
+      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   leak_tracker:
     dependency: transitive
     description:
@@ -334,6 +374,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -354,10 +402,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -374,6 +422,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  objective_c:
+    dependency: transitive
+    description:
+      name: objective_c
+      sha256: "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.1"
+  package_config:
+    dependency: transitive
+    description:
+      name: package_config
+      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   path:
     dependency: transitive
     description:
@@ -394,18 +458,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: f2c65e21139ce2c3dad46922be8272bb5963516045659e71bb16e151c93b580e
+      sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.22"
+    version: "2.3.1"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "6d13aece7b3f5c5a9731eaf553ff9dcbc2eff41087fd2df587fd0fed9a3eb0c4"
+      sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.1"
+    version: "2.6.0"
   path_provider_linux:
     dependency: transitive
     description:
@@ -454,14 +518,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.5+1"
+  pub_semver:
+    dependency: transitive
+    description:
+      name: pub_semver
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
+  record_use:
+    dependency: transitive
+    description:
+      name: record_use
+      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   share_plus:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "14c8860d4de93d3a7e53af51bff479598c4e999605290756bbbe45cf65b37840"
+      sha256: "223873d106614442ea6f20db5a038685cc5b32a2fba81cdecaefbbae0523f7fa"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.1"
+    version: "12.0.2"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -479,10 +559,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   stack_trace:
     dependency: transitive
     description:
@@ -519,10 +599,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:
@@ -551,10 +631,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.3"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -567,10 +647,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.2"
+    version: "4.5.3"
   vector_math:
     dependency: transitive
     description:
@@ -583,18 +663,18 @@ packages:
     dependency: "direct dev"
     description:
       name: very_good_analysis
-      sha256: "96245839dbcc45dfab1af5fa551603b5c7a282028a64746c19c547d21a7f1e3a"
+      sha256: d1cb1d66a5aae2c702d68caca6c8347306d35e728fd94555fa21fa0448a972e0
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.2.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "15.2.0"
   web:
     dependency: transitive
     description:
@@ -619,6 +699,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  yaml:
+    dependency: transitive
+    description:
+      name: yaml
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
 sdks:
-  dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.35.0"
+  dart: ">=3.11.0 <4.0.0"
+  flutter: ">=3.38.4"

--- a/flutter_meta_wearables_dat_mock_device/CHANGELOG.md
+++ b/flutter_meta_wearables_dat_mock_device/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.1
+
+* Future-proof Android Gradle scripts for Flutter's [Built-in Kotlin migration](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors). The Kotlin Gradle Plugin is now applied conditionally (`if (agpMajor < 9)`) — once a consumer upgrades to AGP 9, KGP will be auto-injected by Flutter's tooling and this plugin will stop contributing to the `Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP)` warning. On AGP < 9 (current Flutter 3.44 baseline) nothing changes: KGP is still applied so the plugin continues to compile, and the warning continues to fire from this and other plugins in the same situation until the host app moves to AGP 9.
+* Replace the deprecated `android.kotlinOptions { }` block with the modern top-level `kotlin.compilerOptions { }` DSL.
+* No API changes; consumers do not need to change anything beyond bumping the dependency.
+
 ## 0.5.0
 
 * Update to DAT SDK 0.7.0. Drop-in upgrade — no API changes.

--- a/flutter_meta_wearables_dat_mock_device/android/build.gradle
+++ b/flutter_meta_wearables_dat_mock_device/android/build.gradle
@@ -24,7 +24,16 @@ allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+// Flutter is moving to "Built-in Kotlin" with AGP 9 (Flutter 3.44+); applying
+// the Kotlin Gradle Plugin there both triggers a deprecation warning and will
+// fail the build in a future Flutter release. Apply KGP only on the legacy
+// path; on AGP 9+, AGP injects Kotlin support itself.
+// https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: "kotlin-android"
+}
 
 android {
     namespace = "io.rodcone.flutter_meta_wearables_dat_mock_device"
@@ -34,10 +43,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
     }
 
     sourceSets {
@@ -71,5 +76,11 @@ android {
                showStandardStreams = true
             }
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }

--- a/flutter_meta_wearables_dat_mock_device/ios/flutter_meta_wearables_dat_mock_device.podspec
+++ b/flutter_meta_wearables_dat_mock_device/ios/flutter_meta_wearables_dat_mock_device.podspec
@@ -14,7 +14,7 @@ the binary and skip the matching Info.plist usage strings.
                        DESC
   s.homepage         = 'https://github.com/rodcone/flutter_meta_wearables_dat'
   s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
+  s.author           = { 'Gautier de Lataillade' => 'gautier@levinriegner.com' }
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'

--- a/flutter_meta_wearables_dat_mock_device/pubspec.lock
+++ b/flutter_meta_wearables_dat_mock_device/pubspec.lock
@@ -119,10 +119,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -188,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:
@@ -212,10 +212,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "046d3928e16fa4dc46e8350415661755ab759d9fc97fc21b5ab295f71e4f0499"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "15.1.0"
+    version: "15.2.0"
 sdks:
   dart: ">=3.11.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/flutter_meta_wearables_dat_mock_device/pubspec.yaml
+++ b/flutter_meta_wearables_dat_mock_device/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_meta_wearables_dat_mock_device
 description: "Optional MockDeviceKit add-on for flutter_meta_wearables_dat — simulates a Ray-Ban Meta device using the phone's camera. Pull this in only for development and testing; production apps should omit it to avoid linking AVFoundation/Camera symbols."
-version: 0.5.0
+version: 0.5.1
 repository: https://github.com/rodcone/flutter_meta_wearables_dat
 
 environment:

--- a/ios/Classes/MetaWearablesDatPlugin.swift
+++ b/ios/Classes/MetaWearablesDatPlugin.swift
@@ -231,9 +231,17 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
       do {
         let status = try await Wearables.shared.checkPermissionStatus(.camera)
         result(status == .granted)
-      } catch is MWDATCore.PermissionError {
-        // Permission not granted yet or denied — return false instead of error
-        result(false)
+      } catch let e as MWDATCore.PermissionError {
+        // Mirror Android's typed-exception contract: surface no-device / Meta-AI-missing
+        // / timeout / etc. as the same FlutterError codes `requestCameraPermission`
+        // already emits. Returning `false` here would conflate contract failures with
+        // a real "user denied" outcome on the Dart side.
+        let code = Self.mapPermissionError(e)
+        result(FlutterError(
+          code: code,
+          message: e.description,
+          details: ["errorType": String(describing: e), "rawValue": e.rawValue]
+        ))
       } catch {
         result(FlutterError(code: "INTERNAL_ERROR", message: error.localizedDescription, details: nil))
       }

--- a/ios/Classes/MetaWearablesDatPlugin.swift
+++ b/ios/Classes/MetaWearablesDatPlugin.swift
@@ -198,10 +198,31 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
         let granted = status == .granted
         result(granted)
       } catch let e as MWDATCore.PermissionError {
-        result(FlutterError(code: "PERMISSION_ERROR", message: e.localizedDescription, details: e.rawValue))
+        let code = Self.mapPermissionError(e)
+        result(FlutterError(
+          code: code,
+          message: e.description,
+          details: ["errorType": String(describing: e), "rawValue": e.rawValue]
+        ))
       } catch {
-        result(FlutterError(code: "PERMISSION_ERROR", message: error.localizedDescription, details: nil))
+        result(FlutterError(code: "INTERNAL_ERROR", message: error.localizedDescription, details: nil))
       }
+    }
+  }
+
+  /// Map an SDK `PermissionError` to one of the typed codes that
+  /// `CameraPermissionException` predicates on the Dart side. `PERMISSION_DENIED`
+  /// is reserved for the case where a user explicitly declines the request — the
+  /// SDK doesn't surface that as an error (it returns `.denied`), so it's never
+  /// emitted here.
+  private static func mapPermissionError(_ e: MWDATCore.PermissionError) -> String {
+    switch e {
+    case .noDevice, .noDeviceWithConnection, .connectionError:
+      return "DEVICE_DISCONNECTED"
+    case .metaAINotInstalled, .requestInProgress, .requestTimeout, .internalError:
+      return "INTERNAL_ERROR"
+    @unknown default:
+      return "INTERNAL_ERROR"
     }
   }
 
@@ -214,7 +235,7 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
         // Permission not granted yet or denied — return false instead of error
         result(false)
       } catch {
-        result(FlutterError(code: "PERMISSION_ERROR", message: error.localizedDescription, details: nil))
+        result(FlutterError(code: "INTERNAL_ERROR", message: error.localizedDescription, details: nil))
       }
     }
   }

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "flutter_meta_wearables_dat",
-    platforms: [.iOS("14.0")],
+    platforms: [.iOS("17.0")],
     products: [
         .library(name: "flutter_meta_wearables_dat", targets: ["flutter_meta_wearables_dat"])
     ],
@@ -17,20 +17,14 @@ let package = Package(
             name: "MWDATCamera",
             path: "Frameworks/MWDATCamera.xcframework"
         ),
-        .binaryTarget(
-            name: "MWDATMockDevice",
-            path: "Frameworks/MWDATMockDevice.xcframework"
-        ),
         .target(
             name: "flutter_meta_wearables_dat",
             dependencies: [
                 "MWDATCore",
-                "MWDATCamera",
-                "MWDATMockDevice"
+                "MWDATCamera"
             ],
             path: "Classes",
             resources: []
         )
     ]
 )
-

--- a/ios/flutter_meta_wearables_dat.podspec
+++ b/ios/flutter_meta_wearables_dat.podspec
@@ -5,13 +5,16 @@
 Pod::Spec.new do |s|
   s.name             = 'flutter_meta_wearables_dat'
   s.version          = '0.5.0'
-  s.summary          = 'A new Flutter plugin project.'
+  s.summary          = "Flutter bridge to Meta's Wearables DAT for iOS and Android."
   s.description      = <<-DESC
-A new Flutter plugin project.
+Flutter plugin providing a bridge to Meta's Wearables Device Access Toolkit (DAT)
+for integration with Meta AI Glasses (Ray-Ban Meta). Supports device registration,
+camera permissions, video streaming with raw (BGRA) and hvc1 (HEVC) codecs, photo
+capture, and background streaming on iOS 17.0+.
                        DESC
-  s.homepage         = 'http://example.com'
+  s.homepage         = 'https://github.com/rodcone/flutter_meta_wearables_dat'
   s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
+  s.author           = { 'Gautier de Lataillade' => 'gautier@levinriegner.com' }
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
@@ -29,9 +32,7 @@ A new Flutter plugin project.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386', 'OTHER_LDFLAGS' => '-lc++' }
   s.swift_version = '5.0'
 
-  # If your plugin requires a privacy manifest, for example if it uses any
-  # required reason APIs, update the PrivacyInfo.xcprivacy file to describe your
-  # plugin's privacy impact, and then uncomment this line. For more information,
-  # see https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
-  # s.resource_bundles = {'flutter_meta_wearables_dat_privacy' => ['Resources/PrivacyInfo.xcprivacy']}
+  # Privacy manifest declares no required-reason API usage and no tracking; ship
+  # it so consumers' aggregated privacy report stays accurate.
+  s.resource_bundles = {'flutter_meta_wearables_dat_privacy' => ['Resources/PrivacyInfo.xcprivacy']}
 end

--- a/lib/flutter_meta_wearables_dat.dart
+++ b/lib/flutter_meta_wearables_dat.dart
@@ -283,13 +283,21 @@ class CameraPermissionException implements Exception {
     this.details,
   });
 
-  /// Returns true if the device is disconnected or powered off.
+  /// Returns true when the request failed because no Ray-Ban Meta device was
+  /// reachable (powered off, out of Bluetooth range, or the Meta AI app
+  /// reports no connection).
   bool get isDeviceDisconnected => code == 'DEVICE_DISCONNECTED';
 
-  /// Returns true if the permission was denied by the user.
+  /// Reserved for cases where the SDK surfaces a denial as an exception.
+  /// In the current SDK a user denying the prompt is *not* an error — it
+  /// returns `false` from [MetaWearablesDat.requestCameraPermission].
+  /// Treat a `false` return as denial; this predicate stays for forward
+  /// compatibility.
   bool get isPermissionDenied => code == 'PERMISSION_DENIED';
 
-  /// Returns true if there was an internal SDK error.
+  /// Returns true for any other SDK-side failure (request already in
+  /// progress, timeout, Meta AI app not installed, generic internal error,
+  /// or an unrecognized error type).
   bool get isInternalError => code == 'INTERNAL_ERROR';
 
   @override
@@ -664,16 +672,21 @@ class MetaWearablesDat {
     return MetaWearablesDatPlatform.instance.disableBackgroundStreaming();
   }
 
-  /// Stream of per-frame [VideoFrame] events, emitted in both foreground and
-  /// background when background streaming is enabled.
+  /// Stream of per-frame [VideoFrame] events. Emitted whenever a Dart
+  /// subscriber is attached — the native side short-circuits serialization
+  /// when no listener is present, so there is zero per-frame cost for apps
+  /// that don't need the feed.
   ///
   /// Use this when you want to record the stream to disk or run custom
   /// per-frame processing. For preview rendering, the zero-copy `Texture`
   /// returned by [startStreamSession] is always the right choice — it
   /// bypasses the platform channel.
   ///
-  /// Subscribers have no effect when background streaming is disabled; the
-  /// native side short-circuits serialization so there is no per-frame cost.
+  /// On iOS, frames keep flowing while the app is backgrounded only if
+  /// [enableBackgroundStreaming] has been called (iOS otherwise suspends
+  /// the underlying capture). On Android, [enableBackgroundStreaming] is
+  /// what keeps the OS from killing the streaming process once the app
+  /// leaves the foreground.
   static Stream<VideoFrame> videoFramesStream() {
     return MetaWearablesDatPlatform.instance.videoFramesStream();
   }

--- a/lib/meta_wearables_dat_method_channel.dart
+++ b/lib/meta_wearables_dat_method_channel.dart
@@ -215,7 +215,9 @@ class MethodChannelMetaWearablesDat extends MetaWearablesDatPlatform {
   Stream<RegistrationState> registrationStateStream() {
     return eventChannel.receiveBroadcastStream().map((dynamic event) {
       final state = RegistrationState.fromInt(event as int);
-      debugPrint('[MetaWearablesDAT] registrationState → $state');
+      if (kDebugMode) {
+        debugPrint('[MetaWearablesDAT] registrationState → $state');
+      }
       return state;
     });
   }
@@ -226,7 +228,9 @@ class MethodChannelMetaWearablesDat extends MetaWearablesDatPlatform {
       dynamic event,
     ) {
       final state = StreamSessionState.fromInt(event as int);
-      debugPrint('[MetaWearablesDAT] streamSessionState → $state');
+      if (kDebugMode) {
+        debugPrint('[MetaWearablesDAT] streamSessionState → $state');
+      }
       return state;
     });
   }
@@ -241,9 +245,11 @@ class MethodChannelMetaWearablesDat extends MetaWearablesDatPlatform {
         code: map['code'] as String,
         message: map['message'] as String,
       );
-      debugPrint(
-        '[MetaWearablesDAT] streamSessionError → ${err.code}: ${err.message}',
-      );
+      if (kDebugMode) {
+        debugPrint(
+          '[MetaWearablesDAT] streamSessionError → ${err.code}: ${err.message}',
+        );
+      }
       return err;
     });
   }
@@ -254,7 +260,9 @@ class MethodChannelMetaWearablesDat extends MetaWearablesDatPlatform {
       dynamic event,
     ) {
       final available = event as bool;
-      debugPrint('[MetaWearablesDAT] activeDevice → $available');
+      if (kDebugMode) {
+        debugPrint('[MetaWearablesDAT] activeDevice → $available');
+      }
       return available;
     });
   }
@@ -269,9 +277,11 @@ class MethodChannelMetaWearablesDat extends MetaWearablesDatPlatform {
         width: (map['width'] as num).toInt(),
         height: (map['height'] as num).toInt(),
       );
-      debugPrint(
-        '[MetaWearablesDAT] videoStreamSize → ${size.width}x${size.height}',
-      );
+      if (kDebugMode) {
+        debugPrint(
+          '[MetaWearablesDAT] videoStreamSize → ${size.width}x${size.height}',
+        );
+      }
       return size;
     });
   }
@@ -341,9 +351,11 @@ class MethodChannelMetaWearablesDat extends MetaWearablesDatPlatform {
           (map['thermalLevel'] as num).toInt(),
         ),
       );
-      debugPrint(
-        '[MetaWearablesDAT] deviceState → thermalLevel=${state.thermalLevel}',
-      );
+      if (kDebugMode) {
+        debugPrint(
+          '[MetaWearablesDAT] deviceState → thermalLevel=${state.thermalLevel}',
+        );
+      }
       return state;
     });
   }

--- a/lib/meta_wearables_dat_method_channel.dart
+++ b/lib/meta_wearables_dat_method_channel.dart
@@ -213,49 +213,67 @@ class MethodChannelMetaWearablesDat extends MetaWearablesDatPlatform {
 
   @override
   Stream<RegistrationState> registrationStateStream() {
-    return eventChannel.receiveBroadcastStream().map(
-      (dynamic event) => RegistrationState.fromInt(event as int),
-    );
+    return eventChannel.receiveBroadcastStream().map((dynamic event) {
+      final state = RegistrationState.fromInt(event as int);
+      debugPrint('[MetaWearablesDAT] registrationState → $state');
+      return state;
+    });
   }
 
   @override
   Stream<StreamSessionState> streamSessionStateStream() {
-    return streamSessionStateEventChannel.receiveBroadcastStream().map(
-      (dynamic event) => StreamSessionState.fromInt(event as int),
-    );
+    return streamSessionStateEventChannel.receiveBroadcastStream().map((
+      dynamic event,
+    ) {
+      final state = StreamSessionState.fromInt(event as int);
+      debugPrint('[MetaWearablesDAT] streamSessionState → $state');
+      return state;
+    });
   }
 
   @override
   Stream<StreamSessionError> streamSessionErrorStream() {
-    return streamSessionErrorEventChannel.receiveBroadcastStream().map(
-      (dynamic event) {
-        final map = Map<String, dynamic>.from(event as Map);
-        return StreamSessionError(
-          code: map['code'] as String,
-          message: map['message'] as String,
-        );
-      },
-    );
+    return streamSessionErrorEventChannel.receiveBroadcastStream().map((
+      dynamic event,
+    ) {
+      final map = Map<String, dynamic>.from(event as Map);
+      final err = StreamSessionError(
+        code: map['code'] as String,
+        message: map['message'] as String,
+      );
+      debugPrint(
+        '[MetaWearablesDAT] streamSessionError → ${err.code}: ${err.message}',
+      );
+      return err;
+    });
   }
 
   @override
   Stream<bool> activeDeviceStream() {
-    return activeDeviceEventChannel.receiveBroadcastStream().map(
-      (dynamic event) => event as bool,
-    );
+    return activeDeviceEventChannel.receiveBroadcastStream().map((
+      dynamic event,
+    ) {
+      final available = event as bool;
+      debugPrint('[MetaWearablesDAT] activeDevice → $available');
+      return available;
+    });
   }
 
   @override
   Stream<VideoStreamSize> videoStreamSizeStream() {
-    return videoStreamSizeEventChannel.receiveBroadcastStream().map(
-      (dynamic event) {
-        final map = Map<String, dynamic>.from(event as Map);
-        return VideoStreamSize(
-          width: (map['width'] as num).toInt(),
-          height: (map['height'] as num).toInt(),
-        );
-      },
-    );
+    return videoStreamSizeEventChannel.receiveBroadcastStream().map((
+      dynamic event,
+    ) {
+      final map = Map<String, dynamic>.from(event as Map);
+      final size = VideoStreamSize(
+        width: (map['width'] as num).toInt(),
+        height: (map['height'] as num).toInt(),
+      );
+      debugPrint(
+        '[MetaWearablesDAT] videoStreamSize → ${size.width}x${size.height}',
+      );
+      return size;
+    });
   }
 
   @override
@@ -314,15 +332,19 @@ class MethodChannelMetaWearablesDat extends MetaWearablesDatPlatform {
 
   @override
   Stream<DeviceState> deviceStateStream() {
-    return deviceStateEventChannel.receiveBroadcastStream().map(
-      (dynamic event) {
-        final map = Map<String, dynamic>.from(event as Map);
-        return DeviceState(
-          thermalLevel: ThermalLevel.fromInt(
-            (map['thermalLevel'] as num).toInt(),
-          ),
-        );
-      },
-    );
+    return deviceStateEventChannel.receiveBroadcastStream().map((
+      dynamic event,
+    ) {
+      final map = Map<String, dynamic>.from(event as Map);
+      final state = DeviceState(
+        thermalLevel: ThermalLevel.fromInt(
+          (map['thermalLevel'] as num).toInt(),
+        ),
+      );
+      debugPrint(
+        '[MetaWearablesDAT] deviceState → thermalLevel=${state.thermalLevel}',
+      );
+      return state;
+    });
   }
 }

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,54 @@
+# flutter_meta_wearables_dat
+
+> Flutter plugin bridging Meta's Wearables Device Access Toolkit (DAT) — register, stream the camera, capture photos, and capture raw video frames from **Ray-Ban Meta (Gen 1 & 2)**, **Meta Ray-Ban Display**, **Oakley Meta HSTN**, and **Oakley Meta Vanguard** smart glasses. iOS 17+ and Android API 29+. Published by verified publisher rodcone.io; tracks the latest DAT SDK release (currently 0.7.0) and is updated within days of each Meta release.
+
+The package exposes a single static facade, `MetaWearablesDat`, that delegates through a `MetaWearablesDatPlatform` interface to a Swift implementation on iOS (using the vendored `MWDATCore` / `MWDATCamera` xcframeworks) and a Kotlin implementation on Android (using the `mwdat-core` / `mwdat-camera` Maven dependencies from GitHub Packages). Integration follows a four-phase lifecycle: **Android permissions → registration (via Meta AI deep link) → camera permission → streaming**. Streaming returns a Flutter `Texture` ID for zero-copy rendering; reactive state and errors are exposed as Dart `Stream`s on dedicated event channels. Mock-device support lives in a separate optional add-on so production builds do not need to declare `NSCameraUsageDescription` (iOS) or the `CAMERA` permission (Android).
+
+## Public API
+
+- [lib/flutter_meta_wearables_dat.dart](https://github.com/rodcone/flutter_meta_wearables_dat/blob/main/lib/flutter_meta_wearables_dat.dart): the `MetaWearablesDat` static facade — every public method consumers call.
+- [lib/meta_wearables_dat_platform_interface.dart](https://github.com/rodcone/flutter_meta_wearables_dat/blob/main/lib/meta_wearables_dat_platform_interface.dart): abstract platform contract.
+- [lib/meta_wearables_dat_method_channel.dart](https://github.com/rodcone/flutter_meta_wearables_dat/blob/main/lib/meta_wearables_dat_method_channel.dart): default method/event channel implementation.
+
+## Compatible devices
+
+- Ray-Ban Meta (Gen 1)
+- Ray-Ban Meta (Gen 2)
+- Meta Ray-Ban Display
+- Oakley Meta HSTN
+- Oakley Meta Vanguard
+
+## Integration lifecycle
+
+- [Setup](https://github.com/rodcone/flutter_meta_wearables_dat#setup): iOS `Info.plist`, Android manifest, GitHub Packages Maven repo, `MainActivity` must extend `FlutterFragmentActivity`.
+- [Phase 0 — Android permissions](https://github.com/rodcone/flutter_meta_wearables_dat#0-android-permissions-android-only): `requestAndroidPermissions()`; gates SDK initialization on Android, no-op on iOS.
+- [Phase 1 — Registration](https://github.com/rodcone/flutter_meta_wearables_dat#1-registration-one-time): `startRegistration()` + deep-link callback through `handleUrl()` from the Meta AI app.
+- [Phase 2 — Camera permission](https://github.com/rodcone/flutter_meta_wearables_dat#2-permissions-first-time-camera-access): `requestCameraPermission()`.
+- [Phase 3 — Streaming](https://github.com/rodcone/flutter_meta_wearables_dat#3-session-after-registration-and-permissions): `startStreamSession()` returns a texture ID; subscribe to `streamSessionStateStream()`, `streamSessionErrorStream()`, `videoStreamSizeStream()`, `deviceStateStream()`.
+- [Background streaming](https://github.com/rodcone/flutter_meta_wearables_dat#background-streaming): opt in with `enableBackgroundStreaming()` before starting the session — iOS keeps the process alive via an `AVAudioSession`; Android runs a foreground service with a `connectedDevice` type and a `PARTIAL_WAKE_LOCK`.
+- [Raw video frames](https://github.com/rodcone/flutter_meta_wearables_dat#accessing-raw-frame-bytes): `videoFramesStream()` delivers BGRA / I420 / hvc1 NAL payloads for recording, ML, or re-muxing — zero-cost when no listener is attached.
+
+## AI assistant resources
+
+- [AGENTS.md](https://github.com/rodcone/flutter_meta_wearables_dat/blob/main/AGENTS.md): full AI-readable reference — code style, architecture, every type, every method signature, integration lifecycle, platform differences, debugging tree. Compatible with 20+ AI tools.
+- [agent/](https://github.com/rodcone/flutter_meta_wearables_dat/tree/main/agent): Claude Code skills + commands, Cursor `.mdc` rules, and GitHub Copilot instructions ready to drop into a consumer project.
+- [install-skills.sh](https://github.com/rodcone/flutter_meta_wearables_dat/blob/main/install-skills.sh): one-liner to install the assistant config of your choice (`claude` / `cursor` / `copilot` / `agents` / `all`).
+
+## Optional mock-device add-on
+
+- [flutter_meta_wearables_dat_mock_device](https://github.com/rodcone/flutter_meta_wearables_dat/tree/main/flutter_meta_wearables_dat_mock_device): simulates a Ray-Ban Meta from the phone camera for development without physical glasses. Pulled in only for dev/staging; production apps that omit it ship without `MWDATMockDevice.xcframework` / `mwdat-mockdevice` and without camera-permission declarations.
+
+## Example app
+
+- [example/](https://github.com/rodcone/flutter_meta_wearables_dat/tree/main/example): full-stack Flutter app demonstrating the four-phase lifecycle — deep-link wiring (via `app_links`), `Provider`-based state management, registration, streaming with live `Texture` rendering, photo capture, thermal monitoring, and optional mock-device flows.
+
+## Changelog
+
+- [CHANGELOG.md](https://github.com/rodcone/flutter_meta_wearables_dat/blob/main/CHANGELOG.md): release cadence and per-version notes. Latest release pairs with DAT 0.7.0 and adds thermal monitoring, peak-power / battery-critical error codes, and the `openDATGlassesAppUpdate()` recovery path.
+
+## Optional
+
+- [pub.dev package page](https://pub.dev/packages/flutter_meta_wearables_dat)
+- [Meta's official DAT API reference (llms.txt)](https://wearables.developer.meta.com/llms.txt?full=true): authoritative upstream SDK reference.
+- [Meta Wearables Developer Center](https://wearables.developer.meta.com/): registration, app IDs, client tokens.
+- [Meta's AI-Assisted Development guide](https://wearables.developer.meta.com/docs/ai-assisted)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_meta_wearables_dat
 description: "Flutter bridge to Meta's Wearables DAT for iOS and Android."
-version: 0.5.0
+version: 0.5.1
 repository: https://github.com/rodcone/flutter_meta_wearables_dat
 
 environment:


### PR DESCRIPTION
Changes shipped:

  Phase: 1 — Stop secret leaks
  Files: .pubignore
  What changed: Added example/android/secrets.properties + example/ios/Flutter/Secrets.xcconfig. Verified gone from dart pub publish --dry-run for both
    packages.
  ────────────────────────────────────────
  Phase: 2 — Typed permission errors
  Files: MetaWearablesDatPlugin.swift:187 (ios/Classes/MetaWearablesDatPlugin.swift:187), MetaWearablesDatPlugin.kt:459
    (android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt:459)
  What changed: Both platforms now map PermissionError/MWDATCore.PermissionError cases to DEVICE_DISCONNECTED
    (noDevice/noDeviceWithConnection/connectionError) or INTERNAL_ERROR (metaAINotInstalled/requestInProgress/requestTimeout/internalError). Added
    mapPermissionError helpers. Added details map with the SDK case name for callers that want to drill in.
  ────────────────────────────────────────
  Phase: 3 — iOS Package.swift
  Files: Package.swift (ios/Package.swift)
  What changed: Bumped platform 14→17, removed MWDATMockDevice binary target + dep. swift package describe now succeeds.
  ────────────────────────────────────────
  Phase: 4 — Podspec + privacy manifest
  Files: flutter_meta_wearables_dat.podspec (ios/flutter_meta_wearables_dat.podspec), flutter_meta_wearables_dat_mock_device.podspec
    (flutter_meta_wearables_dat_mock_device/ios/flutter_meta_wearables_dat_mock_device.podspec)
  What changed: Real summary/description/homepage/author; uncommented s.resource_bundles to ship the privacy manifest. pod lib lint passes for both.
    Confirmed plugin Swift uses no required-reason APIs, so the empty manifest is factually correct.
  ────────────────────────────────────────
  Phase: 5 — Shipped docs
  Files: flutter_meta_wearables_dat.dart:267 (lib/flutter_meta_wearables_dat.dart:267), flutter_meta_wearables_dat.dart:670
    (lib/flutter_meta_wearables_dat.dart:670), README.md:384, AGENTS.md:424, camera-streaming.md:89 (agent/claude/skills/camera-streaming.md:89),
    permissions.md:33 (agent/claude/skills/permissions.md:33)
  What changed: Rewrote videoFramesStream() doc to match hasListener-only gating; fixed iOS raw-frame layout (bytesPerRow * height, not width * height *
  4);
    clarified isPermissionDenied is reserved (SDK returns false for denials, doesn't throw); updated the CameraPermissionException example accordingly.
  ────────────────────────────────────────
  Phase: 6 — Maintainer docs
  Files: MAINTAINERS.md (doc/MAINTAINERS.md), doc/android/Documentation.md
  What changed: 0.6.0 → 0.7.0; renamed StreamSessionStateStreamHandler.kt → StreamStateStreamHandler.kt; StreamSessionState → StreamState; Android
    background-streaming + error-publisher rows updated to reflect 0.5.0+/0.7.0 reality.