### PR TITLE
ci: gate CI + publishing on a perfect pana score (160/160)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,29 @@ jobs:
           fi
           echo "OK: both packages are at $CORE_VERSION"
 
+  # Gate on a perfect pub.dev score for both packages. pana is the analyzer
+  # behind pub.dev's "pub points"; --exit-code-threshold 0 fails the job when
+  # any points are lost (max - granted > 0), so every release stays at
+  # 160/160. Runs on a clean checkout so pana resolves the package itself.
+  pana:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - .
+          - flutter_meta_wearables_dat_mock_device
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Activate pana
+        run: dart pub global activate pana
+      - name: pana (require full pub points)
+        working-directory: ${{ matrix.package }}
+        run: dart pub global run pana --no-warning --exit-code-threshold 0 .
+
   # Build the example app on both iOS resolvers. Example app is committed in
   # its CocoaPods baseline state; on the SPM job Flutter migrates the
   # pbxproj on the fly. Catches regressions on either path.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,6 +50,17 @@ jobs:
           dart analyze --fatal-infos lib/
           if [ -d test ]; then flutter test; else echo "No test directory, skipping"; fi
 
+      # Hard quality gate: refuse to publish unless BOTH packages score a
+      # perfect 160/160 on pana (the analyzer behind pub.dev's pub points).
+      # --exit-code-threshold 0 fails the job if any points are lost.
+      - name: Activate pana
+        run: dart pub global activate pana
+      - name: pana — core (require full pub points)
+        run: dart pub global run pana --no-warning --exit-code-threshold 0 .
+      - name: pana — mock add-on (require full pub points)
+        working-directory: flutter_meta_wearables_dat_mock_device
+        run: dart pub global run pana --no-warning --exit-code-threshold 0 .
+
       # Publish core first; if the mock add-on fails afterwards, re-tag
       # patch-level after fixing — the core publish is not retried, so a
       # half-publish is recoverable by bumping both packages to the next

--- a/flutter_meta_wearables_dat_mock_device/lib/flutter_meta_wearables_dat_mock_device.dart
+++ b/flutter_meta_wearables_dat_mock_device/lib/flutter_meta_wearables_dat_mock_device.dart
@@ -178,10 +178,7 @@ class MetaWearablesDatMockDevice {
   ///
   /// Mutually exclusive with [setCameraFeed] — calling either clears
   /// the source configured by the other.
-  static Future<bool> setCameraFacing(
-    String deviceUUID,
-    CameraFacing facing,
-  ) {
+  static Future<bool> setCameraFacing(String deviceUUID, CameraFacing facing) {
     return MetaWearablesDatMockDevicePlatform.instance.setCameraFacing(
       deviceUUID,
       facing,

--- a/flutter_meta_wearables_dat_mock_device/lib/flutter_meta_wearables_dat_mock_device_method_channel.dart
+++ b/flutter_meta_wearables_dat_mock_device/lib/flutter_meta_wearables_dat_mock_device_method_channel.dart
@@ -116,10 +116,7 @@ class MethodChannelMetaWearablesDatMockDevice
   }
 
   @override
-  Future<bool> setCameraFacing(
-    String deviceUUID,
-    CameraFacing facing,
-  ) async {
+  Future<bool> setCameraFacing(String deviceUUID, CameraFacing facing) async {
     final ok = await methodChannel.invokeMethod<bool>('setCameraFacing', {
       'deviceUUID': deviceUUID,
       'cameraFacing': facing.value,

--- a/flutter_meta_wearables_dat_mock_device/lib/flutter_meta_wearables_dat_mock_device_platform_interface.dart
+++ b/flutter_meta_wearables_dat_mock_device/lib/flutter_meta_wearables_dat_mock_device_platform_interface.dart
@@ -47,10 +47,7 @@ abstract class MetaWearablesDatMockDevicePlatform extends PlatformInterface {
     throw UnimplementedError('unpairGlasses() has not been implemented.');
   }
 
-  Future<bool> setPermission(
-    Permission permission,
-    PermissionStatus status,
-  ) {
+  Future<bool> setPermission(Permission permission, PermissionStatus status) {
     throw UnimplementedError('setPermission() has not been implemented.');
   }
 

--- a/flutter_meta_wearables_dat_mock_device/pubspec.yaml
+++ b/flutter_meta_wearables_dat_mock_device/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_meta_wearables_dat_mock_device
-description: "Optional MockDeviceKit add-on for flutter_meta_wearables_dat — simulates a Ray-Ban Meta device using the phone's camera. Pull this in only for development and testing; production apps should omit it to avoid linking AVFoundation/Camera symbols."
+description: "Optional MockDeviceKit add-on for flutter_meta_wearables_dat — simulate Meta glasses using the phone's camera for development and testing. Omit in production."
 version: 0.7.0
 repository: https://github.com/rodcone/flutter_meta_wearables_dat
 

--- a/flutter_meta_wearables_dat_mock_device/test/flutter_meta_wearables_dat_mock_device_method_channel_test.dart
+++ b/flutter_meta_wearables_dat_mock_device/test/flutter_meta_wearables_dat_mock_device_method_channel_test.dart
@@ -52,17 +52,20 @@ void main() {
     expect(calls.single.arguments, {'deviceUUID': 'uuid-123'});
   });
 
-  test('facade delegates pairGlasses(model) to the platform instance', () async {
-    final fake = _FakeMockPlatform();
-    MetaWearablesDatMockDevicePlatform.instance = fake;
+  test(
+    'facade delegates pairGlasses(model) to the platform instance',
+    () async {
+      final fake = _FakeMockPlatform();
+      MetaWearablesDatMockDevicePlatform.instance = fake;
 
-    final uuid = await MetaWearablesDatMockDevice.pairGlasses(
-      model: GlassesModel.oakleyMetaHSTN,
-    );
+      final uuid = await MetaWearablesDatMockDevice.pairGlasses(
+        model: GlassesModel.oakleyMetaHSTN,
+      );
 
-    expect(fake.lastModel, GlassesModel.oakleyMetaHSTN);
-    expect(uuid, 'fake-uuid');
-  });
+      expect(fake.lastModel, GlassesModel.oakleyMetaHSTN);
+      expect(uuid, 'fake-uuid');
+    },
+  );
 }
 
 class _FakeMockPlatform extends MetaWearablesDatMockDevicePlatform {

--- a/lib/flutter_meta_wearables_dat.dart
+++ b/lib/flutter_meta_wearables_dat.dart
@@ -798,9 +798,7 @@ class MetaWearablesDat {
           FrameFormat.rawStraightRgba => ui.ImageByteFormat.rawStraightRgba,
           FrameFormat.png => ui.ImageByteFormat.png,
         };
-        final byteData = await image.toByteData(
-          format: imageByteFormat,
-        );
+        final byteData = await image.toByteData(format: imageByteFormat);
         if (byteData == null) return null;
         return CapturedFrame(
           bytes: byteData.buffer.asUint8List(),

--- a/lib/meta_wearables_dat_method_channel.dart
+++ b/lib/meta_wearables_dat_method_channel.dart
@@ -166,9 +166,7 @@ class MethodChannelMetaWearablesDat extends MetaWearablesDatPlatform {
     String? deviceId, {
     PhotoCaptureFormat format = PhotoCaptureFormat.jpeg,
   }) async {
-    final args = <String, dynamic>{
-      'format': format.value,
-    };
+    final args = <String, dynamic>{'format': format.value};
     if (deviceId != null) {
       args['deviceId'] = deviceId;
     }
@@ -318,24 +316,24 @@ class MethodChannelMetaWearablesDat extends MetaWearablesDatPlatform {
 
   @override
   Stream<VideoFrame> videoFramesStream() {
-    return videoFramesEventChannel.receiveBroadcastStream().map(
-      (dynamic event) {
-        final map = Map<String, dynamic>.from(event as Map);
-        final codecStr = map['codec'] as String? ?? 'raw';
-        final codec = codecStr == 'hvc1' ? VideoCodec.hvc1 : VideoCodec.raw;
-        final bytes = map['bytes'] as Uint8List;
-        final bytesPerRow = (map['bytesPerRow'] as num?)?.toInt();
-        return VideoFrame(
-          codec: codec,
-          bytes: bytes,
-          width: (map['width'] as num).toInt(),
-          height: (map['height'] as num).toInt(),
-          presentationTimestampUs: (map['ptsUs'] as num).toInt(),
-          isKeyframe: (map['isKeyframe'] as bool?) ?? true,
-          bytesPerRow: bytesPerRow,
-        );
-      },
-    );
+    return videoFramesEventChannel.receiveBroadcastStream().map((
+      dynamic event,
+    ) {
+      final map = Map<String, dynamic>.from(event as Map);
+      final codecStr = map['codec'] as String? ?? 'raw';
+      final codec = codecStr == 'hvc1' ? VideoCodec.hvc1 : VideoCodec.raw;
+      final bytes = map['bytes'] as Uint8List;
+      final bytesPerRow = (map['bytesPerRow'] as num?)?.toInt();
+      return VideoFrame(
+        codec: codec,
+        bytes: bytes,
+        width: (map['width'] as num).toInt(),
+        height: (map['height'] as num).toInt(),
+        presentationTimestampUs: (map['ptsUs'] as num).toInt(),
+        isKeyframe: (map['isKeyframe'] as bool?) ?? true,
+        bytesPerRow: bytesPerRow,
+      );
+    });
   }
 
   @override

--- a/lib/meta_wearables_dat_platform_interface.dart
+++ b/lib/meta_wearables_dat_platform_interface.dart
@@ -104,9 +104,7 @@ abstract class MetaWearablesDatPlatform extends PlatformInterface {
   }
 
   Stream<bool> activeDeviceStream() {
-    throw UnimplementedError(
-      'activeDeviceStream() has not been implemented.',
-    );
+    throw UnimplementedError('activeDeviceStream() has not been implemented.');
   }
 
   Future<List<WearableDevice>> getDevices() {


### PR DESCRIPTION
## What

Adds [pana](https://pub.dev/packages/pana) (the analyzer behind pub.dev's "pub points") as a quality gate:

- **CI (`ci.yml`)** — a new `pana` matrix job runs both packages through `pana --exit-code-threshold 0`, **failing the PR if any pub point is lost**.
- **Publish (`publish.yml`)** — the same gate runs before `dart pub publish`, so a tag whose packages don't score **160/160 cannot reach pub.dev**.

## Why 160/160 wasn't reached before

pana flagged both packages; the fixes are in this branch:

| Package | Was | Issue | Fix |
|---|---|---|---|
| mock | 140 | pubspec description 246 chars (max 180) | shortened to 160 |
| mock | — | new method-channel test not formatted | `dart format` |
| both | 150 | `lib` not clean under pana's (latest-language) formatter | reformatted to the latest style |

Both packages now score **160/160** (verified locally with `pana 0.23.13`).

The reformat note: pana formats with the SDK's *latest* language version (no resolved `package_config`), which differed from the resolved-3.9 output on a few files. The latest-formatter output is **also** accepted by the resolved formatter and `dart analyze`, so it satisfies pana *and* the existing config-aware CI format step.

## Caveat (by design)

`--exit-code-threshold 0` means **any** future point loss blocks CI/publish — including ecosystem-driven drops (a dependency going stale, a new pana check, or the **built-in-Kotlin** penalty pana currently only *warns* about). That's the intended "must be perfect" behavior; relax the threshold if it becomes noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)