### PR TITLE
fix(example): auto-recover stream after lock/unlock

### DIFF
--- a/example/lib/providers/stream_provider.dart
+++ b/example/lib/providers/stream_provider.dart
@@ -35,6 +35,32 @@ class StreamSessionProvider extends ChangeNotifier {
   int? _textureId;
   bool _backgroundStreamingEnabled = false;
 
+  // --- Transparent recovery from transient mid-stream errors -------------
+  // The DAT SDK auto-stops the stream when it hits certain errors ("The
+  // session automatically stops when an error occurs" — SDK docs). The most
+  // common trigger in practice is locking the phone while streaming: the app
+  // is suspended, the pipeline breaks, and the SDK emits `videoStreamingError`
+  // (and transitions the stream to `stopped`). Rather than dead-ending on a
+  // red banner the user can only clear by manually stopping + starting, we
+  // restart the session automatically a few times.
+  static const Set<String> _recoverableStreamErrors = {
+    'videoStreamingError',
+    'timeout',
+    'internalError',
+    'deviceNotConnected',
+    'deviceNotFound',
+  };
+  static const int _maxRecoveryAttempts = 3;
+  static const Duration _recoveryWatchdog = Duration(seconds: 10);
+
+  // True between a user-initiated start and stop — i.e. the user wants the
+  // stream up. Gates auto-recovery so we never fight a deliberate stop.
+  bool _streamingIntended = false;
+  bool _isRecovering = false;
+  int _recoveryAttempts = 0;
+  Timer? _recoveryBackoffTimer;
+  Timer? _recoveryWatchdogTimer;
+
   List<WearableDevice> _devices = <WearableDevice>[];
   bool _devicesLoading = false;
   String? _devicesError;
@@ -71,6 +97,12 @@ class StreamSessionProvider extends ChangeNotifier {
   VideoStreamSize? get videoStreamSize => _videoStreamSize;
   bool get supportsHvc1 => Platform.isIOS;
   bool get backgroundStreamingEnabled => _backgroundStreamingEnabled;
+
+  /// True while the provider is transparently restarting a stream that hit a
+  /// transient error (e.g. after the phone was locked and the app suspended).
+  /// The UI shows a "Reconnecting…" affordance instead of a hard error while
+  /// this is set.
+  bool get isRecovering => _isRecovering;
 
   /// Snapshot of paired devices from the last [refreshDevices] call.
   List<WearableDevice> get devices => _devices;
@@ -237,6 +269,8 @@ class StreamSessionProvider extends ChangeNotifier {
     _sessionErrorSubscription?.cancel();
     _videoStreamSizeSubscription?.cancel();
     _deviceStateSubscription?.cancel();
+    _recoveryBackoffTimer?.cancel();
+    _recoveryWatchdogTimer?.cancel();
     super.dispose();
   }
 
@@ -295,11 +329,92 @@ class StreamSessionProvider extends ChangeNotifier {
   }
 
   void _setError(StreamSessionError error) {
+    // Transient mid-stream failures (notably `videoStreamingError`, which the
+    // SDK emits when the pipeline breaks — e.g. after the phone is locked and
+    // the app is suspended) auto-stop the stream. Rather than dead-ending on a
+    // red banner the user can only clear by manually restarting, transparently
+    // restart the session a few times before surfacing the error.
+    if (_streamingIntended &&
+        _recoverableStreamErrors.contains(error.code) &&
+        _recoveryAttempts < _maxRecoveryAttempts) {
+      _scheduleRecovery(error);
+      return;
+    }
+    _cancelRecovery();
     _lastError = error;
     notifyListeners();
   }
 
-  Future<void> startStreamSession() async {
+  void _scheduleRecovery(StreamSessionError error) {
+    _recoveryAttempts++;
+    _isRecovering = true;
+    // Suppress the error banner while we retry; the UI shows a lightweight
+    // "Reconnecting…" state driven by [isRecovering] instead.
+    notifyListeners();
+    debugPrint(
+      '[MetaWearablesDAT] transient stream error "${error.code}" — '
+      'auto-recovery attempt $_recoveryAttempts/$_maxRecoveryAttempts',
+    );
+
+    _recoveryBackoffTimer?.cancel();
+    _recoveryBackoffTimer = Timer(
+      Duration(milliseconds: 400 * _recoveryAttempts),
+      () => unawaited(_runRecovery(error)),
+    );
+
+    // Safety net: if the stream never gets back to `streaming` and no further
+    // error arrives (e.g. the device is genuinely gone), stop pretending to
+    // reconnect and surface the error.
+    _recoveryWatchdogTimer?.cancel();
+    _recoveryWatchdogTimer = Timer(_recoveryWatchdog, () {
+      if (!_isRecovering) return;
+      _cancelRecovery();
+      _lastError = error;
+      notifyListeners();
+    });
+  }
+
+  Future<void> _runRecovery(StreamSessionError error) async {
+    if (!_streamingIntended) {
+      _cancelRecovery();
+      notifyListeners();
+      return;
+    }
+    // Reuse the normal start path: the native side tears down the auto-stopped
+    // stream and mints a fresh texture, and [startStreamSession] re-subscribes
+    // the state/error streams. Success is confirmed asynchronously when the
+    // state stream reaches `streaming` (see the state subscription), which
+    // clears the recovery flags; a fresh async error re-enters [_setError] and
+    // drives the next attempt.
+    final started = await startStreamSession();
+    if (started || !_streamingIntended) return;
+
+    // Synchronous failure with no error event (e.g. the device session could
+    // not be started): retry or give up.
+    if (_recoveryAttempts >= _maxRecoveryAttempts) {
+      _cancelRecovery();
+      _lastError = error;
+      notifyListeners();
+    } else {
+      _scheduleRecovery(error);
+    }
+  }
+
+  void _cancelRecovery() {
+    _recoveryBackoffTimer?.cancel();
+    _recoveryBackoffTimer = null;
+    _recoveryWatchdogTimer?.cancel();
+    _recoveryWatchdogTimer = null;
+    _isRecovering = false;
+  }
+
+  /// Starts (or, during recovery, restarts) the stream session. Returns true
+  /// once a texture is obtained. A user-initiated start (i.e. not an internal
+  /// recovery restart, which runs while [_isRecovering]) refreshes the
+  /// recovery budget and marks intent to keep streaming.
+  Future<bool> startStreamSession() async {
+    if (!_isRecovering) _recoveryAttempts = 0;
+    _streamingIntended = true;
     try {
       // Set camera feed if video is selected (only for mock devices)
       if (_selectedVideo != null && mockDeviceProvider.deviceUUID != null) {
@@ -326,6 +441,11 @@ class StreamSessionProvider extends ChangeNotifier {
               if (state == StreamSessionState.stopped) {
                 _isStreaming = false;
                 _textureId = null;
+              } else if (state == StreamSessionState.streaming) {
+                // A (re)established stream confirms recovery succeeded: clear
+                // the in-flight recovery and refresh the retry budget.
+                _recoveryAttempts = 0;
+                _cancelRecovery();
               }
               notifyListeners();
               // Keep an open paired-devices sheet's "Streaming" badge in sync as
@@ -378,10 +498,17 @@ class StreamSessionProvider extends ChangeNotifier {
       _isStreaming = false;
       notifyListeners();
     }
+    return _isStreaming;
   }
 
   Future<void> stopStreamSession() async {
     unawaited(HapticFeedback.mediumImpact());
+
+    // An explicit stop cancels any in-flight auto-recovery and clears intent
+    // so a queued restart never fights the user's decision to stop.
+    _streamingIntended = false;
+    _recoveryAttempts = 0;
+    _cancelRecovery();
 
     try {
       await MetaWearablesDat.stopStreamSession(_selectedDeviceId);

--- a/example/lib/screens/stream/stream_screen.dart
+++ b/example/lib/screens/stream/stream_screen.dart
@@ -109,13 +109,17 @@ class _StreamScreenState extends State<StreamScreen> {
 
         return Stack(
           children: [
-            // Full screen video stream or placeholder
+            // Full screen video stream, reconnecting overlay, or placeholder
             Positioned.fill(
-              child: streamProvider.isStreaming
+              child:
+                  streamProvider.isStreaming &&
+                      streamProvider.textureId != null
                   ? _TextureStreamWidget(
                       textureId: streamProvider.textureId!,
                       videoStreamSize: streamProvider.videoStreamSize,
                     )
+                  : streamProvider.isRecovering
+                  ? const _ReconnectingView()
                   : ColoredBox(
                       color: Colors.black,
                       child: Center(
@@ -181,8 +185,20 @@ class _StreamScreenState extends State<StreamScreen> {
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    // Session state label
-                    if (streamProvider.sessionState != null &&
+                    // Session state label ("Reconnecting…" takes precedence
+                    // while auto-recovery is in flight).
+                    if (streamProvider.isRecovering)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 5),
+                        child: Text(
+                          'Reconnecting…',
+                          style: TextStyle(
+                            fontSize: 14,
+                            color: Colors.white.withOpacity(0.7),
+                          ),
+                        ),
+                      )
+                    else if (streamProvider.sessionState != null &&
                         streamProvider.sessionState !=
                             StreamSessionState.streaming &&
                         streamProvider.sessionState !=
@@ -200,7 +216,9 @@ class _StreamScreenState extends State<StreamScreen> {
                     // Show "Waiting for an active device" message when no device is available
                     // Always render it but control visibility with opacity (like native sample app)
                     Opacity(
-                      opacity: canStart ? 0.0 : 1.0,
+                      opacity: canStart || streamProvider.isRecovering
+                          ? 0.0
+                          : 1.0,
                       child: Padding(
                         padding: const EdgeInsets.only(bottom: 5),
                         child: Row(
@@ -223,8 +241,10 @@ class _StreamScreenState extends State<StreamScreen> {
                         ),
                       ),
                     ),
-                    // Show Start button only when not streaming
-                    if (!streamProvider.isStreaming)
+                    // Show Start button only when not streaming and not
+                    // mid-reconnect (auto-recovery drives its own restart).
+                    if (!streamProvider.isStreaming &&
+                        !streamProvider.isRecovering)
                       MetaButton.text(
                         text: 'Start streaming',
                         enabled: canStart,
@@ -367,6 +387,45 @@ class _ThermalChip extends StatelessWidget {
       ThermalLevel.emergency => 'Emergency',
       ThermalLevel.shutdown => 'Shutdown',
     };
+  }
+}
+
+/// Shown while the provider transparently restarts a stream that hit a
+/// transient error (e.g. after the phone was locked and the app suspended).
+/// Reassures the user that the stream is coming back rather than surfacing a
+/// hard error banner.
+class _ReconnectingView extends StatelessWidget {
+  const _ReconnectingView();
+
+  @override
+  Widget build(BuildContext context) {
+    return const ColoredBox(
+      color: Colors.black,
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SizedBox(
+              width: 28,
+              height: 28,
+              child: CircularProgressIndicator(
+                strokeWidth: 2.5,
+                valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+              ),
+            ),
+            SizedBox(height: 16),
+            Text(
+              'Reconnecting…',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+                color: Colors.white,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
 


### PR DESCRIPTION
## Problem

When streaming from the glasses camera (without background streaming enabled), locking the iPhone and then unlocking it back to the stream screen intermittently shows a red **"Video streaming encountered an error"** banner and the stream does **not** resume — you have to manually Stop then Start to get it back. Reproduction rate ~2/5.

```
flutter: [MetaWearablesDAT] streamSessionError → videoStreamingError: Video streaming encountered an error.
```

## Root cause

Locking the phone suspends the app. Intermittently the DAT SDK's stream pipeline breaks and emits `StreamError.videoStreamingError`. Per the SDK's own docs (`doc/ios/MWDATCamera.swift`):

> *"The session automatically stops when an error occurs."*

So that error transitions the `Stream` to `.stopped` — it's **dead**. There is no `pause()`/`resume()` API; recovery requires a fresh `addStream()` + `start()`. On unlock the plugin flips `isInBackground = false` and waits for frames that never arrive. The example app just surfaced the error and gave up, so the only recourse was a manual stop + start.

## Fix

`StreamSessionProvider` now **transparently restarts** the session on *transient* stream errors instead of dead-ending:

- Recoverable codes: `videoStreamingError`, `timeout`, `internalError`, `deviceNotConnected`, `deviceNotFound`.
- Up to **3 attempts** with backoff + a **10s watchdog**; success is confirmed when the state stream reaches `streaming`.
- Gated on user intent (`_streamingIntended`) — an explicit **Stop** cancels any in-flight recovery.
- The stream screen shows a calm **"Reconnecting…"** overlay/label while recovering; the red banner only appears if all attempts are exhausted.

**Deliberate exclusions:** `hingesClosed` (Meta's no-auto-resume-on-doff design) and thermal/battery/power errors are *not* auto-retried.

## Why the example app, not the plugin

Recovery re-invokes `startStreamSession()` — the proven manual stop→start path (native already tears down the stale `.stopped` stream and recreates it). It lives in the app rather than the plugin because retry policy is app-specific **and** `startStreamSession()` mints a *new* texture ID each call, so recovery must flow through Dart to rebind the `Texture` widget; a silent plugin-internal restart would strand the widget on an unregistered texture.

## Testing

- `dart analyze` clean on the whole `example/lib`.
- ⚠️ The underlying bug is hardware-only (needs the glasses + a physical lock/unlock), so this was validated by static analysis and logic tracing, **not** a live device run. Worth a real-device check: stream → lock → unlock a few times and confirm it reconnects (with a brief "Reconnecting…") instead of the red banner.

## Notes

- No plugin (`lib/`) or native changes — example app only. CI's analyze/format jobs don't cover `example/`, and the file's existing (short) formatting style is preserved.
- Possible follow-ups (not in this PR): document in the plugin's `streamSessionErrorStream()` API that these codes are transient so *consumer* apps handle them too; keep a Stop/Cancel button visible during the brief pre-texture reconnect window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
