### PR TITLE
0.8.1 release consistency: podspec versions, lockfiles, stale-callback guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,15 +76,41 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Verify both pubspec versions match
+      # All FOUR version locations must agree, matching the pre-flight checklist
+      # in doc/MAINTAINERS.md. The two pubspecs alone are not enough: the
+      # podspecs carry their own `s.version`, they feed the pod versions
+      # recorded in consumers' Podfile.lock, and nothing else in CI reads them —
+      # 0.8.1 shipped to review with both podspecs still on 0.8.0.
+      - name: Verify all four version locations match
         run: |
-          CORE_VERSION=$(grep '^version:' pubspec.yaml | awk '{print $2}')
-          MOCK_VERSION=$(grep '^version:' flutter_meta_wearables_dat_mock_device/pubspec.yaml | awk '{print $2}')
-          if [ "$CORE_VERSION" != "$MOCK_VERSION" ]; then
-            echo "ERROR: core ($CORE_VERSION) and mock add-on ($MOCK_VERSION) versions must match — they release in lockstep"
+          CORE_PUBSPEC=$(grep '^version:' pubspec.yaml | awk '{print $2}')
+          MOCK_PUBSPEC=$(grep '^version:' flutter_meta_wearables_dat_mock_device/pubspec.yaml | awk '{print $2}')
+          CORE_PODSPEC=$(grep "s.version" ios/flutter_meta_wearables_dat.podspec | head -1 | sed "s/.*'\(.*\)'.*/\1/")
+          MOCK_PODSPEC=$(grep "s.version" flutter_meta_wearables_dat_mock_device/ios/flutter_meta_wearables_dat_mock_device.podspec | head -1 | sed "s/.*'\(.*\)'.*/\1/")
+
+          echo "core   pubspec.yaml : $CORE_PUBSPEC"
+          echo "mock   pubspec.yaml : $MOCK_PUBSPEC"
+          echo "core   podspec      : $CORE_PODSPEC"
+          echo "mock   podspec      : $MOCK_PODSPEC"
+
+          FAIL=0
+          for pair in "mock pubspec:$MOCK_PUBSPEC" "core podspec:$CORE_PODSPEC" "mock podspec:$MOCK_PODSPEC"; do
+            LABEL="${pair%%:*}"
+            VALUE="${pair##*:}"
+            if [ "$VALUE" != "$CORE_PUBSPEC" ]; then
+              echo "ERROR: $LABEL is $VALUE but core pubspec.yaml is $CORE_PUBSPEC"
+              FAIL=1
+            fi
+          done
+          if [ -z "$CORE_PODSPEC" ] || [ -z "$MOCK_PODSPEC" ]; then
+            echo "ERROR: failed to parse a podspec version — check the s.version format"
+            FAIL=1
+          fi
+          if [ "$FAIL" -ne 0 ]; then
+            echo "All four locations must match — they release in lockstep (see doc/MAINTAINERS.md)"
             exit 1
           fi
-          echo "OK: both packages are at $CORE_VERSION"
+          echo "OK: all four version locations are at $CORE_PUBSPEC"
 
   # Gate on a perfect pub.dev score for both packages. pana is the analyzer
   # behind pub.dev's "pub points"; --exit-code-threshold 0 fails the job when

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -528,8 +528,8 @@ Develop and test without physical Meta glasses. Mock support lives in the option
 ```yaml
 # pubspec.yaml — add only in dev/staging configs
 dependencies:
-  flutter_meta_wearables_dat: ^0.8.0
-  flutter_meta_wearables_dat_mock_device: ^0.8.0
+  flutter_meta_wearables_dat: ^0.8.1
+  flutter_meta_wearables_dat_mock_device: ^0.8.1
 ```
 
 ```dart

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ No app-side platform-channel or native video-rendering code, JPEG encoding, or D
 
 ```yaml
 dependencies:
-  flutter_meta_wearables_dat: ^0.8.0
+  flutter_meta_wearables_dat: ^0.8.1
 ```
 
 ### 2. Configure iOS or Android
@@ -666,8 +666,8 @@ Meta gates registration on real glasses, so during development it's often handy 
 ```yaml
 # pubspec.yaml — add only in dev/staging builds
 dependencies:
-  flutter_meta_wearables_dat: ^0.8.0
-  flutter_meta_wearables_dat_mock_device: ^0.8.0
+  flutter_meta_wearables_dat: ^0.8.1
+  flutter_meta_wearables_dat_mock_device: ^0.8.1
 ```
 
 ```dart

--- a/agent/claude/skills/mock-device-testing.md
+++ b/agent/claude/skills/mock-device-testing.md
@@ -11,8 +11,8 @@ Since `flutter_meta_wearables_dat` 0.4.0 the mock APIs live in a separate option
 ```yaml
 # pubspec.yaml
 dependencies:
-  flutter_meta_wearables_dat: ^0.8.0
-  flutter_meta_wearables_dat_mock_device: ^0.8.0
+  flutter_meta_wearables_dat: ^0.8.1
+  flutter_meta_wearables_dat_mock_device: ^0.8.1
 ```
 
 ```dart

--- a/agent/cursor/rules/dat-mock-device.mdc
+++ b/agent/cursor/rules/dat-mock-device.mdc
@@ -10,8 +10,8 @@ Mock APIs live in the optional add-on `flutter_meta_wearables_dat_mock_device` (
 ## Add the dev-only dependency
 ```yaml
 dependencies:
-  flutter_meta_wearables_dat: ^0.8.0
-  flutter_meta_wearables_dat_mock_device: ^0.8.0
+  flutter_meta_wearables_dat: ^0.8.1
+  flutter_meta_wearables_dat_mock_device: ^0.8.1
 ```
 
 ```dart

--- a/agent/github/copilot-instructions.md
+++ b/agent/github/copilot-instructions.md
@@ -37,7 +37,7 @@ All methods are static on `MetaWearablesDat`. Single import: `import 'package:fl
 
 Mock support lives in the optional add-on `flutter_meta_wearables_dat_mock_device` (since 0.4.0). Production builds that omit it skip `MWDATMockDevice` linkage and don't need `NSCameraUsageDescription` / `CAMERA`.
 
-- Add `flutter_meta_wearables_dat_mock_device: ^0.8.0` to dev/staging `pubspec.yaml`.
+- Add `flutter_meta_wearables_dat_mock_device: ^0.8.1` to dev/staging `pubspec.yaml`.
 - Import: `import 'package:flutter_meta_wearables_dat_mock_device/flutter_meta_wearables_dat_mock_device.dart';`
 - Optional bypass for registration/permission flows: `MetaWearablesDatMockDevice.configure(initiallyRegistered: true, initialPermissionsGranted: true)`
 - Lifecycle: `MetaWearablesDatMockDevice.pairGlasses({model})` → UUID (`model` defaults to `GlassesModel.rayBanMeta`; other values: `oakleyMetaHSTN`, `oakleyMetaVanguard`, `rayBanMetaOptics`, `metaGlasses`), then `.powerOn(uuid)` + `.don(uuid)`, optionally `.setCameraFacing(uuid, CameraFacing.back)`

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -36,9 +36,9 @@ PODS:
     - DKImagePickerController/PhotoGallery
     - Flutter
   - Flutter (1.0.0)
-  - flutter_meta_wearables_dat (0.8.0):
+  - flutter_meta_wearables_dat (0.8.1):
     - Flutter
-  - flutter_meta_wearables_dat_mock_device (0.8.0):
+  - flutter_meta_wearables_dat_mock_device (0.8.1):
     - Flutter
     - flutter_meta_wearables_dat
   - image_picker_ios (0.0.1):
@@ -87,9 +87,9 @@ SPEC CHECKSUMS:
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
   file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
-  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_meta_wearables_dat: 1a26cbf3f96ade83444f5a1b08deb688cea751e9
-  flutter_meta_wearables_dat_mock_device: bb90f4374989a7b31c77870c8f3889a655aabaf6
+  Flutter: 71a624a5bc0c04062bf19101d501e466baf2fb47
+  flutter_meta_wearables_dat: f73c6ab13de5e78299c31c82b3a71c66e936d902
+  flutter_meta_wearables_dat_mock_device: c784081236d7b964d5b754365ad5f6fa7add2eee
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a

--- a/example/lib/screens/mock_device/mock_device_sheet.dart
+++ b/example/lib/screens/mock_device/mock_device_sheet.dart
@@ -36,24 +36,28 @@ class MockDeviceSheet extends StatelessWidget {
       alignment: Alignment.topCenter,
       child: Padding(
         padding: const EdgeInsets.only(left: 25, right: 25, bottom: 100),
-        child: Consumer2<MockDeviceProvider, stream_providers.StreamSessionProvider>(
-          builder: (context, mockDeviceProvider, streamProvider, child) {
-            return SingleChildScrollView(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const SheetHandleBar(),
-                  _PairingCard(mockDeviceProvider: mockDeviceProvider),
-                  if (mockDeviceProvider.deviceUUID != null)
-                    _DeviceControlsCard(
-                      mockDeviceProvider: mockDeviceProvider,
-                      streamProvider: streamProvider,
-                    ),
-                ],
-              ),
-            );
-          },
-        ),
+        child:
+            Consumer2<
+              MockDeviceProvider,
+              stream_providers.StreamSessionProvider
+            >(
+              builder: (context, mockDeviceProvider, streamProvider, child) {
+                return SingleChildScrollView(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const SheetHandleBar(),
+                      _PairingCard(mockDeviceProvider: mockDeviceProvider),
+                      if (mockDeviceProvider.deviceUUID != null)
+                        _DeviceControlsCard(
+                          mockDeviceProvider: mockDeviceProvider,
+                          streamProvider: streamProvider,
+                        ),
+                    ],
+                  ),
+                );
+              },
+            ),
       ),
     );
   }
@@ -83,8 +87,9 @@ class _PairingCard extends StatelessWidget {
                 if (paired)
                   Text(
                     'Device paired',
-                    style: Theme.of(context).textTheme.bodyMedium!
-                        .copyWith(color: Colors.green),
+                    style: Theme.of(
+                      context,
+                    ).textTheme.bodyMedium!.copyWith(color: Colors.green),
                   )
                 else
                   const Text('No device paired'),
@@ -363,9 +368,9 @@ class _CameraFacingRow extends StatelessWidget {
             enabled: enabled,
             color: selected == CameraFacing.front ? Colors.green : null,
             onPressed: () {
-              context
-                  .read<MockDeviceProvider>()
-                  .setCameraFacing(CameraFacing.front);
+              context.read<MockDeviceProvider>().setCameraFacing(
+                CameraFacing.front,
+              );
             },
           ),
         ),
@@ -375,9 +380,9 @@ class _CameraFacingRow extends StatelessWidget {
             enabled: enabled,
             color: selected == CameraFacing.back ? Colors.green : null,
             onPressed: () {
-              context
-                  .read<MockDeviceProvider>()
-                  .setCameraFacing(CameraFacing.back);
+              context.read<MockDeviceProvider>().setCameraFacing(
+                CameraFacing.back,
+              );
             },
           ),
         ),

--- a/example/lib/screens/settings/settings_sheet.dart
+++ b/example/lib/screens/settings/settings_sheet.dart
@@ -29,8 +29,8 @@ class SettingsSheet extends StatelessWidget {
             Text(
               'Settings',
               style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                    fontWeight: FontWeight.w700,
-                  ),
+                fontWeight: FontWeight.w700,
+              ),
             ),
             const SizedBox(height: 18),
             const _StreamSettingsSection(),
@@ -218,8 +218,8 @@ class _FpsSlider extends StatelessWidget {
                   fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
                   color: enabled
                       ? (isSelected
-                          ? theme.colorScheme.primary
-                          : theme.colorScheme.onSurface.withOpacity(0.45))
+                            ? theme.colorScheme.primary
+                            : theme.colorScheme.onSurface.withOpacity(0.45))
                       : theme.colorScheme.onSurface.withOpacity(0.25),
                 ),
               );
@@ -303,15 +303,15 @@ class _ResolutionChip extends StatelessWidget {
     final fg = !enabled
         ? theme.colorScheme.onSurface.withOpacity(0.3)
         : selected
-            ? theme.colorScheme.onPrimary
-            : theme.colorScheme.onSurface.withOpacity(0.7);
+        ? theme.colorScheme.onPrimary
+        : theme.colorScheme.onSurface.withOpacity(0.7);
 
     return Material(
       color: !enabled
           ? theme.colorScheme.onSurface.withOpacity(0.04)
           : selected
-              ? theme.colorScheme.primary
-              : theme.colorScheme.onSurface.withOpacity(0.06),
+          ? theme.colorScheme.primary
+          : theme.colorScheme.onSurface.withOpacity(0.06),
       borderRadius: BorderRadius.circular(10),
       child: InkWell(
         onTap: onTap,
@@ -442,10 +442,9 @@ class _SectionTitle extends StatelessWidget {
         Text(
           title,
           style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.w600,
-                color:
-                    Theme.of(context).colorScheme.onSurface.withOpacity(0.8),
-              ),
+            fontWeight: FontWeight.w600,
+            color: Theme.of(context).colorScheme.onSurface.withOpacity(0.8),
+          ),
         ),
       ],
     );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -204,14 +204,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.8.1"
   flutter_meta_wearables_dat_mock_device:
     dependency: "direct main"
     description:
       path: "../flutter_meta_wearables_dat_mock_device"
       relative: true
     source: path
-    version: "0.8.0"
+    version: "0.8.1"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -386,10 +386,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -402,10 +402,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -599,10 +599,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   typed_data:
     dependency: transitive
     description:
@@ -655,10 +655,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   very_good_analysis:
     dependency: "direct dev"
     description:

--- a/flutter_meta_wearables_dat_mock_device/README.md
+++ b/flutter_meta_wearables_dat_mock_device/README.md
@@ -14,8 +14,8 @@ Optional **MockDeviceKit** add-on for [`flutter_meta_wearables_dat`](https://pub
 ```yaml
 # pubspec.yaml
 dependencies:
-  flutter_meta_wearables_dat: ^0.8.0
-  flutter_meta_wearables_dat_mock_device: ^0.8.0
+  flutter_meta_wearables_dat: ^0.8.1
+  flutter_meta_wearables_dat_mock_device: ^0.8.1
 ```
 
 Apps using this package **must** declare the camera permission strings the simulated feed needs:

--- a/flutter_meta_wearables_dat_mock_device/ios/flutter_meta_wearables_dat_mock_device.podspec
+++ b/flutter_meta_wearables_dat_mock_device/ios/flutter_meta_wearables_dat_mock_device.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_meta_wearables_dat_mock_device'
-  s.version          = '0.8.0'
+  s.version          = '0.8.1'
   s.summary          = 'Optional MockDeviceKit add-on for flutter_meta_wearables_dat.'
   s.description      = <<-DESC
 Optional MockDeviceKit add-on for flutter_meta_wearables_dat. Pull this in only

--- a/ios/flutter_meta_wearables_dat.podspec
+++ b/ios/flutter_meta_wearables_dat.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_meta_wearables_dat'
-  s.version          = '0.8.0'
+  s.version          = '0.8.1'
   s.summary          = "Flutter bridge to Meta's Wearables DAT for iOS and Android."
   s.description      = <<-DESC
 Flutter plugin providing a bridge to Meta's Wearables Device Access Toolkit (DAT)

--- a/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/StreamErrorStreamHandler.swift
+++ b/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/StreamErrorStreamHandler.swift
@@ -20,6 +20,13 @@ class StreamErrorStreamHandler: NSObject, FlutterStreamHandler {
   private var eventSink: FlutterEventSink?
   private var listenerToken: AnyListenerToken?
 
+  /// See `StreamStateStreamHandler.subscriptionGeneration` — same hazard, same
+  /// guard. It matters at least as much here: consumers treat a subset of these
+  /// codes as terminal and tear the session down on them, so a stale
+  /// `hingesClosed` from a stream we already dropped would take down its
+  /// replacement.
+  private var subscriptionGeneration: UInt64 = 0
+
   public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
     eventSink = events
     resubscribe()
@@ -54,8 +61,10 @@ class StreamErrorStreamHandler: NSObject, FlutterStreamHandler {
     cancelListener()
     guard let session = session, let events = eventSink else { return }
 
-    listenerToken = session.errorPublisher.listen { error in
+    let generation = subscriptionGeneration
+    listenerToken = session.errorPublisher.listen { [weak self] error in
       Task { @MainActor in
+        guard let self, self.subscriptionGeneration == generation else { return }
         // `errorToMap` returns nil for errors that are deliberately not part of
         // this channel's contract (see `.photoCaptureFailed`).
         guard let payload = Self.errorToMap(error) else { return }
@@ -65,6 +74,9 @@ class StreamErrorStreamHandler: NSObject, FlutterStreamHandler {
   }
 
   private func cancelListener() {
+    // Bump before cancelling — see StreamStateStreamHandler for why the async
+    // token cancel cannot be relied on to stop an in-flight callback.
+    subscriptionGeneration &+= 1
     if let token = listenerToken {
       Task { await token.cancel() }
       listenerToken = nil

--- a/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/StreamStateStreamHandler.swift
+++ b/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/StreamStateStreamHandler.swift
@@ -16,6 +16,23 @@ class StreamStateStreamHandler: NSObject, FlutterStreamHandler {
   private var eventSink: FlutterEventSink?
   private var listenerToken: AnyListenerToken?
 
+  /// Bumped every time we detach from a stream. Callbacks capture the value
+  /// current at subscribe time and drop themselves if it has moved on.
+  ///
+  /// Cancellation alone is not enough to stop a stale state reaching Dart.
+  /// `cancelListener()` can only *start* the cancel (`token.cancel()` is async
+  /// and fire-and-forget), and the listener callback hops through a
+  /// `Task { @MainActor }` before it touches the sink. So an old stream's state
+  /// can already be in flight when we swap streams, and would otherwise land
+  /// after the replacement was seeded — telling Dart the *new* stream is
+  /// `stopped`, or reviving a torn-down one with a stale `streaming`.
+  ///
+  /// Mutated only from `resubscribe()` / `cancelListener()`, which the plugin
+  /// drives from the main thread (`didSet` on `session`, and Flutter's
+  /// `onListen` / `onCancel`), and read on the main actor — the same
+  /// confinement `eventSink` and `listenerToken` already rely on.
+  private var subscriptionGeneration: UInt64 = 0
+
   public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
     eventSink = events
     resubscribe()
@@ -64,15 +81,23 @@ class StreamStateStreamHandler: NSObject, FlutterStreamHandler {
     // Send current state immediately
     events(Self.stateToInt(session.state))
 
-    // Listen for future changes
-    listenerToken = session.statePublisher.listen { state in
+    // Listen for future changes. The generation captured here is what makes a
+    // late callback from a superseded stream drop itself instead of publishing.
+    let generation = subscriptionGeneration
+    listenerToken = session.statePublisher.listen { [weak self] state in
       Task { @MainActor in
+        guard let self, self.subscriptionGeneration == generation else { return }
         events(Self.stateToInt(state))
       }
     }
   }
 
   private func cancelListener() {
+    // Bump first and unconditionally: in-flight callbacks are invalidated the
+    // moment we decide to detach, not whenever the async cancel gets around to
+    // landing. `resubscribe()` calls this before capturing the new generation,
+    // so the new listener always gets a value no stale callback can match.
+    subscriptionGeneration &+= 1
     if let token = listenerToken {
       Task { await token.cancel() }
       listenerToken = nil


### PR DESCRIPTION
Follow-up review on the merged 0.8.1 work ([#22](https://github.com/rodcone/flutter_meta_wearables_dat/pull/22)). All pre-tag — 0.8.1 is not published yet, so no CHANGELOG changes.

## Must-fix

**Both podspecs were still `0.8.0`.** [`doc/MAINTAINERS.md`](doc/MAINTAINERS.md)'s pre-flight checklist requires all four version locations to match; I bumped only the two pubspecs in #22. The podspecs feed the pod versions consumers record in their `Podfile.lock`, so they would have shipped stale.

**`versions-in-sync` extended to all four locations.** Nothing else in CI reads a podspec, which is why this got through. Verified both directions locally: passes on this tree, and fails on a synthetic drift of exactly the shape that shipped —

```
core   pubspec.yaml : 0.8.1
mock   podspec      : 0.8.0
ERROR: mock podspec is 0.8.0 but core pubspec.yaml is 0.8.1
```

**Lockfiles regenerated.** `example/pubspec.lock` resolved both path packages at `0.8.0`; `example/ios/Podfile.lock` recorded both pods at `0.8.0`. Both now `0.8.1`. Two bits of incidental churn ride along and are unavoidable when regenerating on a current toolchain: four Flutter-SDK-pinned transitives (`matcher`, `meta`, `test_api`, `vector_math`) and the `Flutter` pod checksum.

**Stale-callback guard.** Correct that the synchronous `stopped` emission closed the window I introduced but not the pre-existing one underneath it. `cancelListener()` can only *start* the cancel — `token.cancel()` is async and fire-and-forget — and every listener callback hops through a `Task { @MainActor }` before touching the sink, so a superseded stream's state can still be in flight when the replacement is seeded. Callbacks now capture a subscription generation and drop themselves once it moves on. `cancelListener()` bumps it *before* cancelling, so invalidation happens the moment we decide to detach rather than whenever the async cancel lands.

## Beyond the review — please sanity-check this one

I applied the same guard to `StreamErrorStreamHandler`, which has the identical pattern and wasn't flagged. It arguably matters more there: consumers treat a subset of those codes as terminal and tear the session down on them, so a stale `hingesClosed` from a stream we already dropped would take down its replacement. Fixing one and knowingly leaving its twin seemed worse than the small scope creep, but say the word and I'll split it out.

`sendError` is deliberately left unguarded — it's a synthetic push for pre-stream failures and isn't tied to any subscription.

## Polish

- `dart format` on `mock_device_sheet.dart` and `settings_sheet.dart`.
- Install examples → `^0.8.1` in README, mock README, `AGENTS.md`, and the installed assistant files (cursor rules, Claude skill, Copilot instructions). The `0.8.0` references in `CLAUDE.md` are the **DAT SDK** version — a different namespace, deliberately untouched.

## Verification

- **Example iOS release build compiles** — the only real check on the two Swift guards, since CI has no device tests. `✓ Built build/ios/iphoneos/Runner.app`
- `dart analyze --fatal-infos` clean on core, mock, and example
- `dart format --set-exit-if-changed` clean repo-wide
- Four-location gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)