### PR TITLE
Emit terminal stopped on Android; deliver raw frames in background

### DIFF
--- a/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
+++ b/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
@@ -1483,7 +1483,12 @@ class MetaWearablesDatPlugin :
         videoJob = null
         streamErrorJob?.cancel()
         streamErrorJob = null
-        streamStateStreamHandler?.stream = null
+        // Detach *and* tell Dart. A bare `stream = null` cancels the state
+        // collector before `stream.stop()` below produces STOPPING / STOPPED,
+        // so every plugin-initiated teardown reached Dart as silence — a live
+        // texture id and a frozen preview with nothing to react to. Matches the
+        // iOS fix from 0.8.1.
+        streamStateStreamHandler?.detachEmittingStopped()
         // Stop BOTH, stream first — they do different jobs and neither
         // substitutes for the other:
         //

--- a/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/StreamStateStreamHandler.kt
+++ b/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/StreamStateStreamHandler.kt
@@ -42,6 +42,31 @@ internal class StreamStateStreamHandler : EventChannel.StreamHandler {
         eventSink = null
     }
 
+    /**
+     * Detaches from the current stream and pushes a terminal `stopped` to Dart.
+     *
+     * A plain `stream = null` detaches *silently*: [resubscribe] cancels the
+     * collector and returns early on a null stream, so the SDK's STOPPING /
+     * STOPPED transitions produced by the subsequent `stream.stop()` are never
+     * observed. That left every plugin-initiated teardown invisible to Dart —
+     * the app kept a live texture id and a frozen preview with no state change
+     * and no error to act on. iOS fixed this in 0.8.1; Android did not, which
+     * is why the background contract needs it here.
+     *
+     * Safe to double-emit: if the SDK also reported STOPPED before we detached,
+     * Dart sees the same terminal state twice.
+     *
+     * Emits synchronously. Callers run on `Dispatchers.Main.immediate` — the
+     * same dispatcher backing [scope] — so the sink is reachable directly and
+     * the terminal event cannot be reordered behind a restart that re-seeds the
+     * channel.
+     */
+    fun detachEmittingStopped() {
+        stream = null
+        val sink = eventSink ?: return
+        sink.success(STOPPED_VALUE)
+    }
+
     private fun resubscribe() {
         job?.cancel()
         job = null
@@ -62,6 +87,12 @@ internal class StreamStateStreamHandler : EventChannel.StreamHandler {
     }
 
     companion object {
+        /**
+         * The Dart-facing value for `stopped`, used by [detachEmittingStopped].
+         * Derived from [mapState] rather than hard-coded so the two cannot drift.
+         */
+        val STOPPED_VALUE: Int = mapState(StreamState.STOPPED)
+
         /**
          * Maps Android SDK StreamState to int values expected by Dart.
          *

--- a/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/MetaWearablesDatPlugin.swift
+++ b/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/MetaWearablesDatPlugin.swift
@@ -979,11 +979,24 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
     let pts = CMSampleBufferGetPresentationTimeStamp(videoFrame.sampleBuffer)
     let ptsUs: Int64 = pts.isValid ? Int64(CMTimeGetSeconds(pts) * 1_000_000) : 0
 
-    // Forward the hvc1 compressed sample to Dart BEFORE decoding — this lets
-    // apps record the raw bitstream even when no decode path is needed (e.g.
-    // no texture subscriber, or we're backgrounded with no GPU access).
-    if currentVideoCodec == .hvc1, videoFrameHandler.hasListener {
-      videoFrameHandler.emitHvc1(sampleBuffer: videoFrame.sampleBuffer, ptsUs: ptsUs)
+    // Forward the frame to Dart BEFORE the background bail-out, the FPS
+    // throttle, and any decode. Recording subscribers want every frame in both
+    // foreground and background, and neither branch here touches the GPU: hvc1
+    // forwards the CMBlockBuffer the sample already carries, and raw reads the
+    // CVPixelBuffer already attached to it.
+    //
+    // `emitRaw` used to live further down, past `if isInBackground { return }`
+    // and past the throttle. That made two promises false at once: with
+    // `VideoCodec.raw` nothing reached `videoFramesStream()` while backgrounded
+    // even with background streaming on, and raw subscribers silently got a
+    // throttled subset of frames while hvc1 subscribers got all of them.
+    // Android has no such gate; iOS now matches it.
+    if videoFrameHandler.hasListener {
+      if currentVideoCodec == .hvc1 {
+        videoFrameHandler.emitHvc1(sampleBuffer: videoFrame.sampleBuffer, ptsUs: ptsUs)
+      } else if let rawBuffer = CMSampleBufferGetImageBuffer(videoFrame.sampleBuffer) {
+        videoFrameHandler.emitRaw(pixelBuffer: rawBuffer, ptsUs: ptsUs)
+      }
     }
 
     // While backgrounded with bg streaming on (the only way we reach here in


### PR DESCRIPTION
**PR 1 of 4** toward the 0.9.0 background-streaming contract. Both fixes here are standalone bugs that predate that work and stand on their own merits — and the contract depends on the first one, which is why it goes first.

No version bump, no CHANGELOG, no doc changes: those land in PR 4 with the contract.

## Android emitted no terminal `stopped` — on any teardown path

`teardownStreamOnlyLocked()` nulled `streamStateStreamHandler?.stream` *before* `stream?.stop()`. The setter runs `resubscribe()`, which cancels the collector and early-returns on a null stream, so the SDK's `STOPPING`/`STOPPED` transitions were never observed. Consumers were left holding a live texture id and a preview frozen on its last frame, with no state change and no error to react to.

This is the identical bug [#22](https://github.com/rodcone/flutter_meta_wearables_dat/pull/22) fixed on iOS in 0.8.1. Android was never fixed. It affects every plugin-initiated stop today, not just backgrounding.

Adds `detachEmittingStopped()` mirroring the iOS handler. Three deliberate choices:

- **Emit before `stop()`, rather than reordering to observe the SDK's own transition.** Reordering would force `teardownStreamOnly()` to become suspending, and it is called from `onDetachedFromEngine`, which cannot await. It also would not help on the paths that matter most — device gone, session stopped underneath us — where the SDK may never emit `STOPPED` at all.
- **Synchronous emit.** All callers are on `Dispatchers.Main.immediate`, so the terminal event cannot be reordered behind a fast restart's `STARTING`.
- **`STOPPED_VALUE` derived from `mapState(StreamState.STOPPED)`** rather than hard-coded, so it cannot drift from the mapping.

Safe to double-emit, same as iOS: if the SDK also reports `STOPPED`, Dart sees the same terminal state twice.

## iOS dropped raw frames while backgrounded

`emitRaw` sat *after* the `if isInBackground { return }` guard while `emitHvc1` sat before it. So with `enableBackgroundStreaming()` on and `VideoCodec.raw` — the default, and the only codec on Android — `videoFramesStream()` delivered nothing in background. That directly contradicts `README.md:590` and the `VideoFrame` dartdoc, and it defeats the main reason a raw-codec app enables background streaming at all.

Hoisted above the guard. Safe in background: neither branch touches the GPU — hvc1 forwards the `CMBlockBuffer` the sample already carries, raw reads the attached `CVPixelBuffer`. Only decode and `textureFrameAvailable` remain gated.

### Behavior change worth flagging

Raw emission is now **full-rate**. It previously sat after the FPS throttle, so raw subscribers silently got a subset of frames while hvc1 subscribers got all of them. Every frame is the right semantic for recording, and Android has never throttled this path — so this makes the two codecs and the two platforms consistent. Apps that set a low `fps` and subscribe to `videoFramesStream()` will see more callbacks. This gets a CHANGELOG note in PR 4.

## Verification

- Example builds clean on **both** platforms: iOS release (`✓ Built Runner.app`) and release APK (`✓ Built app-release.apk`).
- `dart analyze --fatal-infos` clean.
- Not covered by CI: neither fix is observable without hardware. The Android terminal `stopped` is worth confirming on device — stop a stream and check `streamSessionStateStream()` actually emits, which it never has before on Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)