### PR TITLE
Observe true app background/foreground on both platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,3 +204,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.MWDAT_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
         run: flutter build apk --release
+      # The plugin's Kotlin unit tests. They cover the process-wide foreground
+      # detection rules, which are pure logic and the only part of the
+      # background-streaming behaviour that is verifiable without hardware.
+      # Runs from example/android because the plugin's Gradle project is only
+      # resolvable in the context of a host app.
+      - name: Android unit tests
+        working-directory: example/android
+        env:
+          GITHUB_TOKEN: ${{ secrets.MWDAT_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
+        run: ./gradlew :flutter_meta_wearables_dat:testDebugUnitTest

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -63,9 +63,20 @@ android {
 
         testImplementation("org.jetbrains.kotlin:kotlin-test")
         testImplementation("org.mockito:mockito-core:5.0.0")
+        // `useJUnitPlatform()` below has been configured since before any tests
+        // existed, but without an engine on the test runtime classpath Gradle
+        // discovers zero tests and reports success — so the suite silently did
+        // not run. Required for the JUnit 5 annotations to execute.
+        testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.2")
+        testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.2")
     }
 
     testOptions {
+        // Without this, any `android.util.Log` call reached from code under
+        // test throws "not mocked" and fails the test for a reason that has
+        // nothing to do with the behaviour being asserted.
+        unitTests.returnDefaultValues = true
+
         unitTests.all {
             useJUnitPlatform()
 

--- a/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/AppForegroundTracker.kt
+++ b/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/AppForegroundTracker.kt
@@ -1,0 +1,130 @@
+package io.rodcone.flutter_meta_wearables_dat
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import android.util.Log
+import java.util.Collections
+import java.util.WeakHashMap
+
+/**
+ * Tracks whether the host app is in the foreground, process-wide.
+ *
+ * ## Why `ActivityLifecycleCallbacks` and not the alternatives
+ *
+ * * `ActivityPluginBinding`'s `HiddenLifecycleReference` is **Activity**-scoped,
+ *   not process-scoped. It reports `ON_STOP` on a rotation and on any
+ *   Activity-to-Activity transition inside the same app, so it would stop a
+ *   stream when the user merely opens the app's own settings screen. It also
+ *   needs the `flutter_plugin_android_lifecycle` package to cast safely.
+ * * `ProcessLifecycleOwner` has the right semantics but lives in
+ *   `androidx.lifecycle:lifecycle-process`, which is not on the classpath, and
+ *   drags in `androidx.startup`'s `ContentProvider`. If a host app strips that
+ *   provider — a real startup-time optimisation — the owner silently never
+ *   advances past `INITIALIZED`, which is exactly the kind of quiet failure
+ *   this whole change exists to remove.
+ * * `ActivityLifecycleCallbacks` needs no new dependency (the plugin already
+ *   holds the `Application`), cannot be stripped, and is plain-JVM testable.
+ *   It is what `ProcessLifecycleOwner` wraps.
+ *
+ * ## The four rules that make it correct
+ *
+ * 1. **Identity set, not a counter.** A counter can be corrupted by a missed
+ *    callback and can go negative; a set cannot double-count. Held weakly so a
+ *    leaked Activity cannot pin the app in the "foreground" state forever.
+ * 2. **Edge-triggered, and only after we have seen a foreground.** If the
+ *    plugin attached after the Activity already started — cached engine,
+ *    add-to-app — we never observed the start, so we never claim a background
+ *    transition. Failing closed keeps a live stream alive; failing open would
+ *    kill it.
+ * 3. **Configuration changes are not backgrounding.** `isChangingConfigurations`
+ *    filters rotation and `Activity.recreate()`.
+ * 4. **Debounce before reporting.** Android can deliver `A.onStop` after
+ *    `B.onStart`, and a recreate is a stop/start pair. The delay collapses both.
+ *    This is the same trick `ProcessLifecycleOwner` uses.
+ *
+ * Note the platform asymmetry this leaves, which is inherent and not a bug:
+ * opening Recents and lingering genuinely stops the Activity on Android, so the
+ * app counts as backgrounded, whereas iOS's app switcher only resigns active.
+ * The notification shade does *not* stop the Activity on either platform.
+ */
+internal class AppForegroundTracker(
+        private val debounceMs: Long = DEFAULT_DEBOUNCE_MS,
+        /** Injected so tests can drive time instead of waiting on it. */
+        private val schedule: (Long, () -> Unit) -> Cancellable,
+) : Application.ActivityLifecycleCallbacks {
+
+    /** Something that can be cancelled before it runs. */
+    internal fun interface Cancellable {
+        fun cancel()
+    }
+
+    var onEnteredBackground: (() -> Unit)? = null
+    var onEnteredForeground: (() -> Unit)? = null
+
+    private val startedActivities: MutableSet<Activity> =
+            Collections.newSetFromMap(WeakHashMap<Activity, Boolean>())
+    private var pendingBackground: Cancellable? = null
+    private var everForegrounded = false
+    private var reportedBackground = false
+
+    override fun onActivityStarted(activity: Activity) {
+        val wasEmpty = startedActivities.isEmpty()
+        startedActivities.add(activity)
+        if (!wasEmpty) return
+
+        everForegrounded = true
+        // Cancel a pending background before it fires: this is the
+        // Activity-transition and quick-return case.
+        pendingBackground?.cancel()
+        pendingBackground = null
+        if (reportedBackground) {
+            reportedBackground = false
+            Log.d(TAG, "lifecycle: app entered foreground")
+            onEnteredForeground?.invoke()
+        }
+    }
+
+    override fun onActivityStopped(activity: Activity) {
+        startedActivities.remove(activity)
+        if (startedActivities.isNotEmpty()) return
+        // Rule 3: a recreate is not a background.
+        if (activity.isChangingConfigurations) return
+        // Rule 2: never claim a transition we did not see the other half of.
+        if (!everForegrounded || reportedBackground) return
+
+        pendingBackground?.cancel()
+        pendingBackground =
+                schedule(debounceMs) {
+                    pendingBackground = null
+                    if (startedActivities.isNotEmpty()) return@schedule
+                    reportedBackground = true
+                    Log.d(TAG, "lifecycle: app entered background")
+                    onEnteredBackground?.invoke()
+                }
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+
+    override fun onActivityResumed(activity: Activity) = Unit
+
+    override fun onActivityPaused(activity: Activity) = Unit
+
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+
+    override fun onActivityDestroyed(activity: Activity) {
+        startedActivities.remove(activity)
+    }
+
+    fun dispose() {
+        pendingBackground?.cancel()
+        pendingBackground = null
+        startedActivities.clear()
+    }
+
+    companion object {
+        private const val TAG = "MWDAT"
+        /** Matches `ProcessLifecycleOwner`'s own debounce. */
+        const val DEFAULT_DEBOUNCE_MS = 700L
+    }
+}

--- a/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
+++ b/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
@@ -109,6 +110,14 @@ class MetaWearablesDatPlugin :
     // started so we can idempotently re-start / stop it, and so we can tear
     // it down on plugin detach.
     @Volatile private var backgroundStreamingStarted: Boolean = false
+
+    /**
+     * Process-wide foreground tracking. `isAppInBackground` is the single
+     * source of truth for "the app is not visible"; Android had no notion of
+     * this at all before 0.9.0.
+     */
+    private var foregroundTracker: AppForegroundTracker? = null
+    @Volatile private var isAppInBackground: Boolean = false
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     // Gate SDK initialization until BT permissions are granted (mirrors reference app).
@@ -271,12 +280,71 @@ class MetaWearablesDatPlugin :
 
         val context = flutterPluginBinding.applicationContext
         application = context as? Application
+        registerForegroundTracker()
         // NOTE: Do NOT call ensureWearablesInitialized() here.
         // The reference app initializes the SDK only AFTER Bluetooth permissions
         // are granted. Calling it before permissions breaks device discovery.
         // The SDK will be initialized lazily when first needed (e.g. after
         // requestAndroidPermissions grants BT permissions).
     }
+
+    // region App lifecycle
+
+    /**
+     * Registers the process-wide foreground tracker. Idempotent: re-registering
+     * after a hot restart (where `onDetachedFromEngine` is NOT called, despite
+     * what the comment there used to imply) would otherwise leave one live
+     * tracker per restart, each firing against stale plugin state.
+     */
+    private fun registerForegroundTracker() {
+        val app = application ?: return
+        unregisterForegroundTracker()
+        val tracker =
+                AppForegroundTracker(
+                        schedule = { delayMs, action ->
+                            val job =
+                                    scope.launch {
+                                        delay(delayMs)
+                                        action()
+                                    }
+                            AppForegroundTracker.Cancellable { job.cancel() }
+                        },
+                )
+        tracker.onEnteredBackground = { handleEnteredBackground() }
+        tracker.onEnteredForeground = { handleEnteredForeground() }
+        app.registerActivityLifecycleCallbacks(tracker)
+        foregroundTracker = tracker
+    }
+
+    private fun unregisterForegroundTracker() {
+        val tracker = foregroundTracker ?: return
+        application?.unregisterActivityLifecycleCallbacks(tracker)
+        tracker.dispose()
+        foregroundTracker = null
+    }
+
+    private fun handleEnteredBackground() {
+        isAppInBackground = true
+        // The background stop lands in the next PR. Logged so the hook can be
+        // verified on device before anything acts on it.
+        //
+        // Unlike iOS there is no suspension deadline here: Android does not
+        // freeze the process on backgrounding, so the stop cascade can complete
+        // normally and needs no equivalent of iOS's beginBackgroundTask
+        // assertion. Do not port that here.
+        if (!backgroundStreamingStarted && stream != null) {
+            Log.d(TAG, "lifecycle: would stop stream (background streaming off) — not yet wired")
+        }
+    }
+
+    private fun handleEnteredForeground() {
+        isAppInBackground = false
+        // Deliberately nothing else. With background streaming off the session
+        // is stopped and stays stopped; the plugin never restarts the glasses
+        // camera on its own. Do not add a resume here.
+    }
+
+    // endregion
 
     override fun onMethodCall(call: MethodCall, result: Result) {
         when (call.method) {
@@ -335,6 +403,8 @@ class MetaWearablesDatPlugin :
         deviceStateChannel.setStreamHandler(null)
         deviceStateStreamHandler?.dispose()
         deviceStateStreamHandler = null
+
+        unregisterForegroundTracker()
 
         // Tear down any active session and stream
         teardownSession()

--- a/android/src/test/kotlin/io/rodcone/flutter_meta_wearables_dat/AppForegroundTrackerTest.kt
+++ b/android/src/test/kotlin/io/rodcone/flutter_meta_wearables_dat/AppForegroundTrackerTest.kt
@@ -1,0 +1,159 @@
+package io.rodcone.flutter_meta_wearables_dat
+
+import android.app.Activity
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+/**
+ * Covers the four rules in [AppForegroundTracker] that make process-wide
+ * foreground detection correct. Each of these is a real bug the naive
+ * implementation has, and none of them is observable without a device
+ * otherwise — this is the only part of the background-streaming contract that
+ * can be tested on the JVM.
+ */
+class AppForegroundTrackerTest {
+
+    /** Runs scheduled work only when the test says so. */
+    private class FakeScheduler {
+        private var pending: (() -> Unit)? = null
+        var cancelled = 0
+            private set
+
+        fun schedule(@Suppress("UNUSED_PARAMETER") delayMs: Long, action: () -> Unit):
+                AppForegroundTracker.Cancellable {
+            pending = action
+            return AppForegroundTracker.Cancellable {
+                if (pending != null) cancelled++
+                pending = null
+            }
+        }
+
+        /** Fires the pending job, as the debounce elapsing would. */
+        fun advance() {
+            val action = pending
+            pending = null
+            action?.invoke()
+        }
+
+        val hasPending: Boolean
+            get() = pending != null
+    }
+
+    private lateinit var scheduler: FakeScheduler
+    private lateinit var tracker: AppForegroundTracker
+    private var backgroundCount = 0
+    private var foregroundCount = 0
+
+    @BeforeEach
+    fun setUp() {
+        scheduler = FakeScheduler()
+        backgroundCount = 0
+        foregroundCount = 0
+        tracker = AppForegroundTracker(schedule = scheduler::schedule)
+        tracker.onEnteredBackground = { backgroundCount++ }
+        tracker.onEnteredForeground = { foregroundCount++ }
+    }
+
+    private fun activity(changingConfigurations: Boolean = false): Activity {
+        val a = mock(Activity::class.java)
+        `when`(a.isChangingConfigurations).thenReturn(changingConfigurations)
+        return a
+    }
+
+    @Test
+    fun `start then stop reports background once the debounce elapses`() {
+        val a = activity()
+        tracker.onActivityStarted(a)
+        tracker.onActivityStopped(a)
+
+        assertEquals(0, backgroundCount, "must not fire before the debounce elapses")
+        scheduler.advance()
+        assertEquals(1, backgroundCount)
+        assertEquals(0, foregroundCount)
+    }
+
+    @Test
+    fun `activity to activity transition is not a background`() {
+        // Android guarantees A.onPause -> B.onStart -> A.onStop, so the set is
+        // never empty. A per-activity onStop hook gets this wrong.
+        val a = activity()
+        val b = activity()
+        tracker.onActivityStarted(a)
+        tracker.onActivityStarted(b)
+        tracker.onActivityStopped(a)
+
+        assertEquals(false, scheduler.hasPending, "no background should even be scheduled")
+        scheduler.advance()
+        assertEquals(0, backgroundCount)
+    }
+
+    @Test
+    fun `configuration change is not a background`() {
+        val a = activity(changingConfigurations = true)
+        tracker.onActivityStarted(a)
+        tracker.onActivityStopped(a)
+
+        assertEquals(false, scheduler.hasPending)
+        scheduler.advance()
+        assertEquals(0, backgroundCount, "rotation must not stop the stream")
+    }
+
+    @Test
+    fun `returning within the debounce cancels the pending background`() {
+        val a = activity()
+        tracker.onActivityStarted(a)
+        tracker.onActivityStopped(a)
+        tracker.onActivityStarted(a)
+
+        assertEquals(1, scheduler.cancelled)
+        scheduler.advance()
+        assertEquals(0, backgroundCount)
+        assertEquals(0, foregroundCount, "never went background, so never came foreground")
+    }
+
+    @Test
+    fun `stop without a prior start is ignored`() {
+        // Cached-engine / add-to-app: the plugin attached after the activity
+        // already started, so we never saw the other half of the transition.
+        // Failing closed keeps a live stream alive.
+        tracker.onActivityStopped(activity())
+
+        assertEquals(false, scheduler.hasPending)
+        scheduler.advance()
+        assertEquals(0, backgroundCount)
+    }
+
+    @Test
+    fun `duplicate stop reports background only once`() {
+        val a = activity()
+        tracker.onActivityStarted(a)
+        tracker.onActivityStopped(a)
+        tracker.onActivityStopped(a)
+        scheduler.advance()
+
+        assertEquals(1, backgroundCount)
+    }
+
+    @Test
+    fun `background then foreground reports one of each`() {
+        val a = activity()
+        tracker.onActivityStarted(a)
+        tracker.onActivityStopped(a)
+        scheduler.advance()
+        tracker.onActivityStarted(a)
+
+        assertEquals(1, backgroundCount)
+        assertEquals(1, foregroundCount)
+    }
+
+    @Test
+    fun `foreground is not reported when no background was reported`() {
+        val a = activity()
+        tracker.onActivityStarted(a)
+
+        assertEquals(0, foregroundCount)
+    }
+}

--- a/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/AppLifecycleObserver.swift
+++ b/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/AppLifecycleObserver.swift
@@ -1,0 +1,139 @@
+import UIKit
+
+/// Observes *true* app background / foreground transitions.
+///
+/// ## Why NotificationCenter and not the Flutter plugin lifecycle APIs
+///
+/// `registrar.addApplicationDelegate(_:)` routes through
+/// `FlutterPluginAppLifeCycleDelegate`, which deliberately stops forwarding
+/// application lifecycle events once the host app adopts `UISceneDelegate`.
+/// Flutter's own comment on `-appSupportsSceneLifecycle` says it plainly:
+///
+/// > When UIScene lifecycle is being used, some application lifecycle events
+/// > are not call by UIKit. **However, the notifications are still sent.** When
+/// > a Flutter app has been migrated to UIScene, Flutter should not use the
+/// > notifications to forward application events to plugins since they are not
+/// > expected to be called.
+///
+/// Apps created with current Flutter templates are scene-based by default, so
+/// relying on `addApplicationDelegate` means this plugin silently receives
+/// nothing for a growing share of hosts — the worst kind of failure, because it
+/// looks like the feature works and it simply never fires.
+///
+/// `registrar.addSceneDelegate(_:)` is Flutter's intended answer, but it needs
+/// Flutter 3.38+ (a floor bump for every consumer) *and* only reaches plugins
+/// when the host's scene delegate is, or forwards to, `FlutterSceneDelegate` —
+/// a host with its own plain `UISceneDelegate` still gets nothing.
+///
+/// The notifications themselves are posted by UIKit in every case. Observing
+/// them directly is therefore both broader and cheaper than either Flutter API,
+/// and requires no version floor.
+///
+/// ## What counts as backgrounded
+///
+/// Only a genuine background transition. `willResignActive` /
+/// `didBecomeActive` (and their `UIScene` equivalents) are deliberately **not**
+/// observed: those fire for Control Center, the notification shade, the app
+/// switcher preview, an incoming-call banner, Face ID, and system alerts, none
+/// of which should tear down a stream.
+///
+/// For multi-window hosts, a scene backgrounding is only treated as the app
+/// backgrounding when *every* attached scene is in the background — otherwise
+/// backgrounding one iPad window would kill a stream the other window is still
+/// showing.
+@MainActor
+final class AppLifecycleObserver {
+
+  /// Fired once per background transition, after the latch flips.
+  var onDidEnterBackground: (() -> Void)?
+  /// Fired once per foreground transition, after the latch flips.
+  var onWillEnterForeground: (() -> Void)?
+
+  /// The latch. Also the deduplication mechanism: a non-scene host delivers
+  /// both the `UIApplication` notification and (if the plugin keeps its
+  /// `FlutterApplicationLifeCycleDelegate` conformance) the delegate callback,
+  /// and a multi-scene host delivers one notification per scene.
+  private(set) var isBackgrounded = false
+
+  private var tokens: [NSObjectProtocol] = []
+  private var started = false
+
+  /// Nonisolated so the plugin can hold this as a plain stored property.
+  /// Constructing it touches nothing isolated; `start()` is where main-actor
+  /// work begins.
+  nonisolated init() {}
+
+  func start() {
+    guard !started else { return }
+    started = true
+
+    // `queue: nil` delivers the block synchronously on the posting thread,
+    // which for these UIKit notifications is the main thread. This is
+    // load-bearing rather than incidental: a background teardown has to take a
+    // `beginBackgroundTask` assertion before the handler returns, and hopping
+    // to `OperationQueue.main` would defer that past the point iOS may suspend
+    // us.
+    observe(UIApplication.didEnterBackgroundNotification) { [weak self] in
+      self?.reevaluateBackgroundState()
+    }
+    observe(UIApplication.willEnterForegroundNotification) { [weak self] in
+      self?.noteWillEnterForeground()
+    }
+    observe(UIScene.didEnterBackgroundNotification) { [weak self] in
+      self?.reevaluateBackgroundState()
+    }
+    observe(UIScene.willEnterForegroundNotification) { [weak self] in
+      self?.noteWillEnterForeground()
+    }
+  }
+
+  func stop() {
+    tokens.forEach { NotificationCenter.default.removeObserver($0) }
+    tokens.removeAll()
+    started = false
+  }
+
+  private func observe(_ name: Notification.Name, _ body: @escaping @MainActor () -> Void) {
+    let token = NotificationCenter.default.addObserver(
+      forName: name, object: nil, queue: nil
+    ) { _ in
+      // Deployment target is 17.2, and UIKit posts these on the main thread.
+      MainActor.assumeIsolated { body() }
+    }
+    tokens.append(token)
+  }
+
+  /// Entry point for the `UIApplicationDelegate` callbacks, so a host that
+  /// still delivers them funnels into the same latch instead of double-firing.
+  func noteDidEnterBackground() {
+    guard !isBackgrounded else { return }
+    isBackgrounded = true
+    NSLog("[MWDAT] lifecycle: app entered background")
+    onDidEnterBackground?()
+  }
+
+  func noteWillEnterForeground() {
+    guard isBackgrounded else { return }
+    isBackgrounded = false
+    NSLog("[MWDAT] lifecycle: app entering foreground")
+    onWillEnterForeground?()
+  }
+
+  /// A background notification only counts once nothing is left in front.
+  private func reevaluateBackgroundState() {
+    guard allScenesBackgrounded() else { return }
+    noteDidEnterBackground()
+  }
+
+  /// True when the app as a whole is background, not merely one of its windows.
+  private func allScenesBackgrounded() -> Bool {
+    let app = UIApplication.shared
+    if app.applicationState == .background { return true }
+    let scenes = app.connectedScenes.filter { $0.activationState != .unattached }
+    // No attached scenes at all is ambiguous (pre-attach, or a headless
+    // engine). Treat it as "not backgrounded" so we never tear down a stream on
+    // a state we cannot actually observe.
+    guard !scenes.isEmpty else { return false }
+    return scenes.allSatisfy { $0.activationState == .background }
+  }
+}

--- a/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/MetaWearablesDatPlugin.swift
+++ b/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/MetaWearablesDatPlugin.swift
@@ -145,15 +145,20 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
   // backgrounded apps).
   private let backgroundController = BackgroundStreamingController()
   private let videoFrameHandler = VideoFrameStreamHandler()
+  /// Single source of truth for background/foreground transitions. See
+  /// `AppLifecycleObserver` for why this does not use `addApplicationDelegate`
+  /// or `addSceneDelegate`.
+  private let lifecycleObserver = AppLifecycleObserver()
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "flutter_meta_wearables_dat", binaryMessenger: registrar.messenger())
     let instance = MetaWearablesDatPlugin()
     instance.textureRegistry = registrar.textures()
     registrar.addMethodCallDelegate(instance, channel: channel)
-    // Receive applicationDidEnterBackground / applicationWillEnterForeground
-    // callbacks so we can safely manage the hvc1 HEVC decoder across app
-    // lifecycle transitions (iOS forbids GPU access from backgrounded apps).
+    // Kept as a secondary input only. Flutter stops forwarding these once the
+    // host adopts UISceneDelegate, so `AppLifecycleObserver` — not this — is
+    // what actually guarantees delivery. Both funnel into the same latch, so a
+    // host that delivers both is deduplicated rather than double-handled.
     registrar.addApplicationDelegate(instance)
     // Event channel for registration state updates
     let registrationStateChannel = FlutterEventChannel(name: "flutter_meta_wearables_dat/registration_state", binaryMessenger: registrar.messenger())
@@ -191,6 +196,14 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
     deviceStateChannel.setStreamHandler(deviceStateHandler)
 
     Task { @MainActor in
+      instance.lifecycleObserver.onDidEnterBackground = { [weak instance] in
+        instance?.handleDidEnterBackground()
+      }
+      instance.lifecycleObserver.onWillEnterForeground = { [weak instance] in
+        instance?.handleWillEnterForeground()
+      }
+      instance.lifecycleObserver.start()
+
       try? Wearables.configure()
       // Keep a lifetime subscription on the SDK device list (Meta's canonical
       // pattern, started right after `configure()`) so discovery stays warm and
@@ -951,18 +964,47 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
   // produced grey / corrupted output even in foreground, so the design
   // was reverted: hardware decoder only, always invalidated on background.
 
+  // MARK: - App lifecycle
+  //
+  // These two are thin forwarders. Flutter stops calling them once the host
+  // adopts UISceneDelegate, so they are a secondary input to
+  // `AppLifecycleObserver`, never the primary one. The observer's latch
+  // deduplicates, so a host that delivers both paths still transitions once.
+
   public func applicationDidEnterBackground(_ application: UIApplication) {
+    Task { @MainActor in lifecycleObserver.noteDidEnterBackground() }
+  }
+
+  public func applicationWillEnterForeground(_ application: UIApplication) {
+    Task { @MainActor in lifecycleObserver.noteWillEnterForeground() }
+  }
+
+  /// Runs once per genuine background transition, from whichever input saw it
+  /// first.
+  @MainActor
+  private func handleDidEnterBackground() {
     isInBackground = true
     if let session = decompressionSession {
       VTDecompressionSessionInvalidate(session)
       decompressionSession = nil
       NSLog("[MWDAT] VTDecompressionSession invalidated (app entered background)")
     }
+
+    // The background stop lands in the next PR. Logged here so the hook can be
+    // verified on device — including on a scene-based host, which is the case
+    // `addApplicationDelegate` never reached — before anything acts on it.
+    if !backgroundController.isEnabled && streamSession != nil {
+      NSLog("[MWDAT] lifecycle: would stop stream (background streaming off) — not yet wired")
+    }
   }
 
-  public func applicationWillEnterForeground(_ application: UIApplication) {
+  @MainActor
+  private func handleWillEnterForeground() {
     isInBackground = false
     NSLog("[MWDAT] App entering foreground — HEVC decoder will be recreated on next frame")
+    // Deliberately nothing else. With background streaming off the session is
+    // stopped and stays stopped: the plugin never reactivates the glasses
+    // camera on its own. Do not add a resume here.
   }
 
   // MARK: - Frame Processing (zero-copy via Texture API)


### PR DESCRIPTION
**PR 2 of 4** toward the 0.9.0 background-streaming contract. Stacked on [#24](https://github.com/rodcone/flutter_meta_wearables_dat/pull/24) — review that first; base retargets to `main` once it merges.

**This PR adds detection only. It deliberately does not act on it.** Both handlers log what they *would* do:

```
[MWDAT] lifecycle: app entered background
[MWDAT] lifecycle: would stop stream (background streaming off) — not yet wired
```

The point is that you can confirm the hooks actually fire on your device — including on a scene-based iOS host, which is precisely the case the old hook never reached — before anything destructive hangs off them.

## iOS: not `addApplicationDelegate`, and not `addSceneDelegate`

The plan originally called for `addSceneDelegate` plus a Flutter floor bump to 3.38. Reading the engine source changed that. Flutter's own comment on `-appSupportsSceneLifecycle`:

> When UIScene lifecycle is being used, some application lifecycle events are not call by UIKit. **However, the notifications are still sent.** When a Flutter app has been migrated to UIScene, Flutter should not use the notifications to forward application events to plugins since they are not expected to be called.

So `addApplicationDelegate` receives nothing under scenes *by design*, and current Flutter templates are scene-based by default — the plugin has been silently blind on a growing share of hosts. `addSceneDelegate` is Flutter's intended fix but needs 3.38+ **and** only fires when the host's scene delegate is or forwards to `FlutterSceneDelegate`; a host with its own plain `UISceneDelegate` still gets nothing.

UIKit posts the notifications regardless. Observing them directly is broader, cheaper, and needs **no version floor**.

Three details that are load-bearing rather than incidental:

- **`queue: nil`**, so the block runs synchronously on the posting thread. Hopping to `OperationQueue.main` would defer past the point iOS may suspend us — which matters for the `beginBackgroundTask` assertion in PR 3.
- **`willResignActive` / `didBecomeActive` are not observed.** Those fire for Control Center, the notification shade, the app switcher preview, call banners and Face ID. None should stop a stream.
- **A scene backgrounding only counts when every attached scene is background**, so backgrounding one iPad window can't kill a stream the other window is showing.

The delegate callbacks stay as a secondary input, deduplicated by the observer's latch.

## Android: it had no notion of app background state at all

Not one line, before this. `ActivityAware` exists but only for permission plumbing, and `onDetachedFromActivity` fires on Activity *destroy*, not backgrounding.

`AppForegroundTracker` uses `ActivityLifecycleCallbacks` — **no new dependency**. `ProcessLifecycleOwner` has the right semantics but lives in `lifecycle-process` and drags in `androidx.startup`'s `ContentProvider`; a host that strips that provider (a real startup optimization) gets an owner that silently never advances past `INITIALIZED`. That is exactly the failure mode this change exists to remove.

Four rules, each a real bug in the naive version:

1. **Weak identity set, not a counter** — a counter can be corrupted by a missed callback and go negative.
2. **Edge-triggered, and only after a foreground was observed** — a cached engine that attached late never saw the start, so it never claims a background. Fails closed, keeping a live stream alive.
3. **`isChangingConfigurations` filters rotation** and `recreate()`.
4. **700ms debounce** collapses activity transitions and recreates, same as `ProcessLifecycleOwner`.

Documented asymmetry: lingering in Android Recents genuinely stops the Activity, so it counts as backgrounded, whereas iOS's app switcher only resigns active. Inherent to the platforms.

## Tests — and a CI gap worth knowing about

Eight JVM tests over those four rules. Getting them to run surfaced something: `useJUnitPlatform()` has been configured in `android/build.gradle` since before any tests existed, but **no JUnit engine was ever on the test runtime classpath** — so Gradle discovered zero tests and reported success. Any Kotlin test added at any point would have silently not run.

Fixed by adding the engine, `returnDefaultValues = true` (so `android.util.Log` doesn't throw "not mocked"), and a CI step. A test CI never runs is decoration.

```
8 tests completed, 0 failed
```

## Verification

- 8/8 Kotlin unit tests pass locally and now run in CI.
- Example builds clean on both platforms.
- `dart analyze --fatal-infos` clean (no Dart changes in this PR).

## What to check on device

Watch the log while backgrounding. You should see the lifecycle lines on home, on lock, and **not** on Control Center, the notification shade, or an app-switcher peek. On Android, rotating the device should produce nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)