### PR TITLE
Stop the session on background when background streaming is off

### DIFF
--- a/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
+++ b/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
@@ -338,7 +338,13 @@ class MetaWearablesDatPlugin :
         streamSessionErrorStreamHandler?.sendError(
                 "stoppedForBackground",
                 "The app was backgrounded and background streaming is not enabled.",
+                bypassSuppression = true,
         )
+        // Everything after this is teardown noise. The SDK emits
+        // `videoStreamingError` as the pipeline comes down, which is true when
+        // the stream died on its own and false when we stopped it on purpose.
+        // Bounded so a stalled teardown cannot hide unrelated later errors.
+        streamSessionErrorStreamHandler?.beginBackgroundStopSuppression(scope)
         // The whole session, matching iOS and Meta's CameraAccess sample.
         //
         // Note there is no equivalent of iOS's beginBackgroundTask assertion
@@ -346,6 +352,9 @@ class MetaWearablesDatPlugin :
         // backgrounding, so the stop cascade completes normally. Do not port
         // that machinery over.
         teardownSession()
+        // Teardown is synchronous here, so the window can close immediately
+        // rather than riding out the timeout.
+        streamSessionErrorStreamHandler?.endBackgroundStopSuppression()
     }
 
     private fun handleEnteredForeground() {

--- a/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
+++ b/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
@@ -325,16 +325,27 @@ class MetaWearablesDatPlugin :
 
     private fun handleEnteredBackground() {
         isAppInBackground = true
-        // The background stop lands in the next PR. Logged so the hook can be
-        // verified on device before anything acts on it.
+        // Background streaming ON is the opt-in: keep everything alive.
+        if (backgroundStreamingStarted) return
+        // Nothing live means nothing to stop. Without this, every backgrounding
+        // would emit a terminal `stopped` at idle apps that merely subscribed
+        // to the state channel.
+        if (stream == null && session == null) return
+
+        Log.d(TAG, "lifecycle: stopping session (background streaming off)")
+        // Tell Dart why, before the terminal `stopped`, so consumers can tell a
+        // deliberate stop from a fault and skip their retry logic.
+        streamSessionErrorStreamHandler?.sendError(
+                "stoppedForBackground",
+                "The app was backgrounded and background streaming is not enabled.",
+        )
+        // The whole session, matching iOS and Meta's CameraAccess sample.
         //
-        // Unlike iOS there is no suspension deadline here: Android does not
-        // freeze the process on backgrounding, so the stop cascade can complete
-        // normally and needs no equivalent of iOS's beginBackgroundTask
-        // assertion. Do not port that here.
-        if (!backgroundStreamingStarted && stream != null) {
-            Log.d(TAG, "lifecycle: would stop stream (background streaming off) — not yet wired")
-        }
+        // Note there is no equivalent of iOS's beginBackgroundTask assertion
+        // here, deliberately: Android does not freeze the process on
+        // backgrounding, so the stop cascade completes normally. Do not port
+        // that machinery over.
+        teardownSession()
     }
 
     private fun handleEnteredForeground() {
@@ -1079,10 +1090,32 @@ class MetaWearablesDatPlugin :
 
     // region Streaming
 
+    /**
+     * True when starting would immediately contradict the background contract.
+     * Checked at the commit point too, not just on entry, because a start can
+     * be in flight when the app backgrounds.
+     */
+    private val mustNotStreamNow: Boolean
+        get() = isAppInBackground && !backgroundStreamingStarted
+
     private fun startStreamSession(call: MethodCall, result: Result) {
         val app = application
         if (app == null) {
             result.error("STREAM_ERROR", "Application context is not available.", null)
+            return
+        }
+
+        // Refuse outright while backgrounded — the belt to the contract's
+        // braces. Even a consumer whose retry logic ignores
+        // `stoppedForBackground` cannot reactivate the glasses camera from the
+        // background. Same error code as iOS so Dart handling is uniform.
+        if (mustNotStreamNow) {
+            result.error(
+                    "APP_BACKGROUNDED",
+                    "Cannot start a stream while the app is backgrounded. " +
+                            "Call enableBackgroundStreaming() first if you need background capture.",
+                    null,
+            )
             return
         }
 
@@ -1323,6 +1356,20 @@ class MetaWearablesDatPlugin :
                 if (failure != null) {
                     teardownStreamOnly()
                     result.error("STREAM_ERROR", failure, null)
+                    return@launch
+                }
+                // Last commit point. Bringing a session up can take seconds,
+                // which is ample time for the user to background the app
+                // mid-start. Committing anyway would leave a live stream
+                // running in a backgrounded app that nothing will stop.
+                if (mustNotStreamNow) {
+                    Log.d(TAG, "app backgrounded during start — abandoning")
+                    teardownStreamOnly()
+                    result.error(
+                            "APP_BACKGROUNDED",
+                            "The app was backgrounded before the stream could start.",
+                            null,
+                    )
                     return@launch
                 }
                 result.success(textureId)

--- a/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/StreamSessionErrorStreamHandler.kt
+++ b/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/StreamSessionErrorStreamHandler.kt
@@ -1,8 +1,13 @@
 package io.rodcone.flutter_meta_wearables_dat
 
+import android.util.Log
 import com.meta.wearable.dat.camera.types.StreamError
 import com.meta.wearable.dat.core.types.DeviceSessionError
 import io.flutter.plugin.common.EventChannel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 /**
  * Stream handler for stream-related errors. Acts as a programmable sink that
@@ -31,11 +36,60 @@ internal class StreamSessionErrorStreamHandler : EventChannel.StreamHandler {
         eventSink = null
     }
 
+    /** True while the plugin is deliberately stopping for a background transition. */
+    private var isStoppingForBackground = false
+    private var suppressionExpiry: Job? = null
+
+    /**
+     * Suppresses teardown noise for the duration of a deliberate background
+     * stop.
+     *
+     * The SDK emits `videoStreamingError` as the pipeline comes down. That is
+     * accurate when the stream died on its own and actively false when *we*
+     * stopped it — the app implicitly asked for the stop by backgrounding — so
+     * consumers were rendering a red "streaming encountered an error" banner
+     * for a clean, expected shutdown.
+     *
+     * Bounded on purpose: a stalled teardown must not be able to hide unrelated
+     * later errors indefinitely, so the window closes on a timer even if
+     * [endBackgroundStopSuppression] never arrives. Mirrors iOS.
+     *
+     * `stoppedForBackground` is emitted *before* this opens, so the app still
+     * learns why the session ended.
+     */
+    fun beginBackgroundStopSuppression(
+            scope: CoroutineScope,
+            timeoutMs: Long = DEFAULT_SUPPRESSION_TIMEOUT_MS,
+    ) {
+        isStoppingForBackground = true
+        suppressionExpiry?.cancel()
+        suppressionExpiry =
+                scope.launch {
+                    delay(timeoutMs)
+                    isStoppingForBackground = false
+                    suppressionExpiry = null
+                }
+    }
+
+    fun endBackgroundStopSuppression() {
+        suppressionExpiry?.cancel()
+        suppressionExpiry = null
+        isStoppingForBackground = false
+    }
+
     /**
      * Emit an error event to the Dart side.
      * Map format: `{"code": "...", "message": "..."}`.
+     *
+     * [bypassSuppression] is for the plugin's own deliberate-stop notice, which
+     * must reach Dart even though it opens the suppression window immediately
+     * afterwards.
      */
-    fun sendError(code: String, message: String) {
+    fun sendError(code: String, message: String, bypassSuppression: Boolean = false) {
+        if (!bypassSuppression && isStoppingForBackground) {
+            Log.d(TAG, "suppressed '$code' during background stop")
+            return
+        }
         eventSink?.success(mapOf("code" to code, "message" to message))
     }
 
@@ -65,6 +119,15 @@ internal class StreamSessionErrorStreamHandler : EventChannel.StreamHandler {
     }
 
     companion object {
+        private const val TAG = "MetaWearablesDat"
+
+        /**
+         * Upper bound on the background-stop suppression window. Long enough to
+         * cover a normal teardown, short enough that a stalled one cannot hide
+         * unrelated errors for meaningfully long. Matches iOS.
+         */
+        const val DEFAULT_SUPPRESSION_TIMEOUT_MS = 5_000L
+
         // String-pattern matching against `error.toString()` keeps us
         // forward-compatible: new error cases that aren't explicitly listed
         // here still get a reasonable fallback code rather than crashing.

--- a/example/lib/providers/stream_provider.dart
+++ b/example/lib/providers/stream_provider.dart
@@ -447,7 +447,31 @@ class StreamSessionProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// The plugin stopped the session on purpose because the app was
+  /// backgrounded without `enableBackgroundStreaming()`. Not a failure, and
+  /// emphatically not something to retry: restarting here would reactivate the
+  /// glasses camera from the background, which is what the contract forbids —
+  /// and the plugin would reject it with `APP_BACKGROUNDED` anyway.
+  static const String _backgroundStopCode = 'stoppedForBackground';
+
   Future<void> _setError(StreamSessionError error) async {
+    if (error.code == _backgroundStopCode) {
+      // Disarm recovery before the terminal `stopped` lands. Without this the
+      // SDK's own `videoStreamingError` death-rattle races the deliberate stop
+      // and `_scheduleRecovery` restarts a session we just chose to end.
+      _streamingIntended = false;
+      _recoveryAttempts = 0;
+      _cancelRecovery();
+      // No banner: the user backgrounded the app, they know why it stopped.
+      // The terminal `stopped` clears the texture and re-enables Start.
+      debugPrint('[MetaWearablesDAT] session stopped for background');
+      notifyListeners();
+      return;
+    }
+    return _setStreamError(error);
+  }
+
+  Future<void> _setStreamError(StreamSessionError error) async {
     // A terminal error has already told the user what to do. The SDK keeps
     // emitting teardown noise while that stop converges, and letting it through
     // would swap the actionable message ("put your glasses back on") for a

--- a/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/MetaWearablesDatPlugin.swift
+++ b/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/MetaWearablesDatPlugin.swift
@@ -1014,12 +1014,22 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
     // first because `teardownStreamOnly()` detaches the error handler.
     streamErrorHandler.sendError(
       code: "stoppedForBackground",
-      message: "The app was backgrounded and background streaming is not enabled."
+      message: "The app was backgrounded and background streaming is not enabled.",
+      bypassSuppression: true
     )
+    // Everything after this point is teardown noise. The SDK emits
+    // `videoStreamingError` as the pipeline comes down, which is true when the
+    // stream died on its own and false when we stopped it on purpose — the app
+    // asked for this by backgrounding. Bounded so a stalled teardown cannot
+    // hide unrelated later errors.
+    streamErrorHandler.beginBackgroundStopSuppression()
 
     beginBackgroundStopAssertion()
     Task { @MainActor in
-      defer { endBackgroundStopAssertion() }
+      defer {
+        endBackgroundStopAssertion()
+        streamErrorHandler.endBackgroundStopSuppression()
+      }
       // The whole DeviceSession, not just the stream — matching Meta's
       // CameraAccess sample. Stopping only the stream leaves the plugin as the
       // last strong owner of the `Stream`, which is why that path needs a

--- a/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/MetaWearablesDatPlugin.swift
+++ b/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/MetaWearablesDatPlugin.swift
@@ -149,6 +149,13 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
   /// `AppLifecycleObserver` for why this does not use `addApplicationDelegate`
   /// or `addSceneDelegate`.
   private let lifecycleObserver = AppLifecycleObserver()
+  /// Keeps the process scheduled long enough for a background-triggered
+  /// teardown to reach the glasses. `.invalid` when none is held.
+  private var backgroundStopTaskId: UIBackgroundTaskIdentifier = .invalid
+  /// Set when the assertion expires, so the stop-confirmation poll in
+  /// `performTeardownStreamOnly` gives up instead of burning the last of our
+  /// budget on a wait that cannot finish.
+  private var abortStopWait = false
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "flutter_meta_wearables_dat", binaryMessenger: registrar.messenger())
@@ -893,11 +900,14 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
     // left to stop it.
     if let stoppingStream {
       let deadline = Date().addingTimeInterval(streamStopTimeout)
-      while stoppingStream.state != .stopped, Date() < deadline {
+      // `abortStopWait` lets an expiring background assertion cut the wait
+      // short. Continuing to poll after the OS has told us we are out of time
+      // just burns the last of the budget on a wait that cannot complete.
+      while stoppingStream.state != .stopped, Date() < deadline, !abortStopWait {
         try? await Task.sleep(nanoseconds: 50_000_000)
       }
       if stoppingStream.state != .stopped {
-        NSLog("[MWDAT] stream did not reach .stopped within \(streamStopTimeout)s (state: \(stoppingStream.state))")
+        NSLog("[MWDAT] stream did not reach .stopped (state: \(stoppingStream.state), aborted: \(abortStopWait))")
       }
     }
 
@@ -990,12 +1000,67 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
       NSLog("[MWDAT] VTDecompressionSession invalidated (app entered background)")
     }
 
-    // The background stop lands in the next PR. Logged here so the hook can be
-    // verified on device — including on a scene-based host, which is the case
-    // `addApplicationDelegate` never reached — before anything acts on it.
-    if !backgroundController.isEnabled && streamSession != nil {
-      NSLog("[MWDAT] lifecycle: would stop stream (background streaming off) — not yet wired")
+    // Background streaming ON is the whole point of the opt-in: keep everything
+    // alive and let the preview resume on foreground.
+    guard !backgroundController.isEnabled else { return }
+    // Nothing streaming means nothing to stop. Without this guard every
+    // backgrounding would emit a terminal `stopped` at idle apps that merely
+    // subscribed to the state channel.
+    guard streamSession != nil || deviceSession != nil else { return }
+
+    NSLog("[MWDAT] lifecycle: stopping session (background streaming off)")
+    // Tell Dart *why* before the terminal `stopped` lands, so consumers can
+    // tell a deliberate stop from a fault and skip their retry logic. Emitted
+    // first because `teardownStreamOnly()` detaches the error handler.
+    streamErrorHandler.sendError(
+      code: "stoppedForBackground",
+      message: "The app was backgrounded and background streaming is not enabled."
+    )
+
+    beginBackgroundStopAssertion()
+    Task { @MainActor in
+      defer { endBackgroundStopAssertion() }
+      // The whole DeviceSession, not just the stream — matching Meta's
+      // CameraAccess sample. Stopping only the stream leaves the plugin as the
+      // last strong owner of the `Stream`, which is why that path needs a
+      // 3s poll before releasing (see `performTeardownStreamOnly`). Suspension
+      // mid-poll would then strand a live capability on the glasses and break
+      // the *next* start. Stopping the session makes that unreachable: the SDK
+      // owns it, and the capability goes away with it either way.
+      await teardownDeviceSession()
+      NSLog("[MWDAT] lifecycle: session stopped for background")
     }
+  }
+
+  // MARK: - Background stop assertion
+  //
+  // iOS suspends the process shortly after `didEnterBackground` returns. The
+  // teardown below can take up to `streamStopTimeout`, so without an assertion
+  // it would be frozen mid-cascade. Taken synchronously, before the `Task`, or
+  // the process can be suspended before the Task's first hop even runs.
+
+  private func beginBackgroundStopAssertion() {
+    guard backgroundStopTaskId == .invalid else { return }
+    abortStopWait = false
+    backgroundStopTaskId = UIApplication.shared.beginBackgroundTask(
+      withName: "io.rodcone.mwdat.stopStreamOnBackground"
+    ) { [weak self] in
+      // UIKit calls this on the main thread when our budget runs out. It must
+      // be fast and it MUST end the task, or the watchdog kills the app.
+      MainActor.assumeIsolated {
+        guard let self else { return }
+        self.abortStopWait = true
+        NSLog("[MWDAT] background stop assertion expired — abandoning stop confirmation")
+        self.endBackgroundStopAssertion()
+      }
+    }
+  }
+
+  private func endBackgroundStopAssertion() {
+    guard backgroundStopTaskId != .invalid else { return }
+    UIApplication.shared.endBackgroundTask(backgroundStopTaskId)
+    // Idempotent: ending an already-ended identifier trips a UIKit assertion.
+    backgroundStopTaskId = .invalid
   }
 
   @MainActor
@@ -1194,6 +1259,14 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
 
   // MARK: - Stream Session
 
+  /// True when starting a stream would immediately contradict the background
+  /// contract. Checked at every commit point in `startStreamSession`, not just
+  /// on entry, because a start can be in flight when the app backgrounds.
+  @MainActor
+  private var mustNotStreamNow: Bool {
+    isInBackground && !backgroundController.isEnabled
+  }
+
   func startStreamSession(call: FlutterMethodCall, result: @escaping FlutterResult) {
     guard let args = call.arguments as? [String : Any] else {
       result(FlutterError(code: "INVALID_ARGS", message: "arguments missing", details: nil))
@@ -1216,6 +1289,16 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
       // `.started` forever.
       if isStartingSession {
         result(FlutterError(code: "STREAM_ACTIVE", message: "A stream start is already in progress.", details: nil))
+        return
+      }
+      // Refuse outright while backgrounded. This is the belt to the contract's
+      // braces: even a consumer whose retry logic ignores `stoppedForBackground`
+      // physically cannot reactivate the glasses camera from the background.
+      if mustNotStreamNow {
+        result(FlutterError(
+          code: "APP_BACKGROUNDED",
+          message: "Cannot start a stream while the app is backgrounded. Call enableBackgroundStreaming() first if you need background capture.",
+          details: nil))
         return
       }
       isStartingSession = true
@@ -1340,6 +1423,21 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
       videoListenerToken = session.videoFramePublisher.listen { [weak self] videoFrame in
         guard let self else { return }
         self.processAndSendFrame(videoFrame)
+      }
+
+      // Last commit point. A device session can take up to
+      // `deviceSessionStartTimeout` to come up, which is ample time for the
+      // user to background the app mid-start. Committing here anyway would
+      // install a live stream in a backgrounded app that nothing is going to
+      // stop — the one outcome worse than the freeze this all replaces.
+      if mustNotStreamNow {
+        NSLog("[MWDAT] app backgrounded during start — abandoning")
+        await teardownStreamOnly()
+        result(FlutterError(
+          code: "APP_BACKGROUNDED",
+          message: "The app was backgrounded before the stream could start.",
+          details: nil))
+        return
       }
 
       camera = addedCamera

--- a/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/StreamErrorStreamHandler.swift
+++ b/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/StreamErrorStreamHandler.swift
@@ -39,12 +39,61 @@ class StreamErrorStreamHandler: NSObject, FlutterStreamHandler {
     return nil
   }
 
+  /// True while the plugin is deliberately tearing the session down because
+  /// the app was backgrounded. See `beginBackgroundStopSuppression()`.
+  private var isStoppingForBackground = false
+  private var suppressionExpiry: Task<Void, Never>?
+
+  /// Suppresses teardown noise for the duration of a deliberate background
+  /// stop.
+  ///
+  /// The SDK emits `videoStreamingError` as the pipeline comes down. That is
+  /// accurate when the stream died on its own and actively false when *we*
+  /// stopped it: the app implicitly asked for the stop by backgrounding, so
+  /// telling it "video streaming encountered an error" is misinformation, and
+  /// consumers reasonably render it as a red banner.
+  ///
+  /// Bounded on purpose. A teardown that stalls must not be able to hide
+  /// unrelated later errors indefinitely, so the window closes on a timer even
+  /// if `endBackgroundStopSuppression()` never arrives. Meta's CameraAccess
+  /// sample solves the same problem the same way, app-side; doing it here means
+  /// every consumer gets it rather than each rediscovering the banner.
+  ///
+  /// `stoppedForBackground` is emitted *before* this opens, so the app still
+  /// learns why the session ended.
+  @MainActor
+  func beginBackgroundStopSuppression(timeout: Duration = .seconds(5)) {
+    isStoppingForBackground = true
+    suppressionExpiry?.cancel()
+    suppressionExpiry = Task { @MainActor [weak self] in
+      try? await Task.sleep(for: timeout)
+      guard let self, !Task.isCancelled else { return }
+      self.isStoppingForBackground = false
+      self.suppressionExpiry = nil
+    }
+  }
+
+  @MainActor
+  func endBackgroundStopSuppression() {
+    suppressionExpiry?.cancel()
+    suppressionExpiry = nil
+    isStoppingForBackground = false
+  }
+
   /// Pushes a synthesised error onto the event channel. Used by the plugin
   /// to surface errors that happen before a `Stream` exists (e.g.
   /// `DeviceSession.start()` throwing `.noEligibleDevice`).
-  func sendError(code: String, message: String) {
+  ///
+  /// `bypassSuppression` is for the plugin's own deliberate-stop notice, which
+  /// must reach Dart even though it opens the suppression window immediately
+  /// afterwards.
+  func sendError(code: String, message: String, bypassSuppression: Bool = false) {
     guard let events = eventSink else { return }
     Task { @MainActor in
+      guard bypassSuppression || !self.isStoppingForBackground else {
+        NSLog("[MWDAT] suppressed '\(code)' during background stop")
+        return
+      }
       events(["code": code, "message": message])
     }
   }
@@ -65,6 +114,13 @@ class StreamErrorStreamHandler: NSObject, FlutterStreamHandler {
     listenerToken = session.errorPublisher.listen { [weak self] error in
       Task { @MainActor in
         guard let self, self.subscriptionGeneration == generation else { return }
+        // Teardown noise from a stop we asked for is not an error. This is the
+        // path that produced "Video streaming encountered an error" right after
+        // a deliberate background stop.
+        guard !self.isStoppingForBackground else {
+          NSLog("[MWDAT] suppressed stream error during background stop")
+          return
+        }
         // `errorToMap` returns nil for errors that are deliberately not part of
         // this channel's contract (see `.photoCaptureFailed`).
         guard let payload = Self.errorToMap(error) else { return }


### PR DESCRIPTION
**PR 3 of 4.** Stacked on [#25](https://github.com/rodcone/flutter_meta_wearables_dat/pull/25) → [#24](https://github.com/rodcone/flutter_meta_wearables_dat/pull/24). This is the one that makes the contract real, and the riskiest of the four.

This directly answers the QA finding: with the toggle off, backgrounding or locking now closes the session instead of leaving it open.

## Design change from the plan: stop the session, not the stream

Reading [CameraViewModel.swift:417](doc/ios/meta-wearables-dat-ios/samples/CameraAccess/CameraAccess/ViewModels/CameraViewModel.swift:417) changed this. Meta's sample does:

```swift
private func handleDidEnterBackground() {
  guard hasSession, hasStream, sessionState != .stopping else { return }
  beginBackgroundStopErrorSuppression()
  endSession()          // -> session.stop()
}
```

They stop the whole `DeviceSession`, fire-and-forget — no poll, no background assertion. That works *because* they stop the session: the SDK retains it, so there's no premature-release hazard.

Our plugin's 3-second poll exists only because `teardownStreamOnly()` keeps the session alive, making the plugin the last strong owner of the `Stream`. Releasing early cancels the SDK's stop cascade and strands a live capability on the glasses — and then the *next* start fails. Being suspended mid-poll produces exactly that, which is strictly worse than the freeze we set out to fix.

Stopping the session makes that whole failure class unreachable. **Cost:** the next Start is a full reconnect rather than a fast `addCamera`, so it's slower. Acceptable given there's no auto-resume and the user taps Start deliberately.

iOS still takes a `beginBackgroundTask` assertion as insurance, since `teardownDeviceSession()` calls `teardownStreamOnly()` internally and the poll is still on the path:

- Taken **synchronously before** the `Task` — defer it and the process can be suspended before the Task's first hop runs.
- Ended in a `defer` **and** in the expiration handler, idempotently. An un-ended assertion is a `0x8badf00d` watchdog kill.
- Expiry sets `abortStopWait`, which now cuts the poll short rather than spending the last of the budget on a wait that cannot complete.

**Android deliberately has none of this**, and the code says so, because the process isn't frozen on backgrounding and someone will otherwise "port the iOS fix."

## Two independent safeguards, not one

**`stoppedForBackground`** on the error channel, emitted before the terminal `stopped`, so consumers can tell a deliberate stop from a fault. (Meta's sample solves the same problem app-side with a bounded 5s error-suppression window; signalling is the better fit for a plugin, since consumers shouldn't have to implement suppression.)

**`APP_BACKGROUNDED`** from `startStreamSession` while backgrounded — checked on entry *and* at the final commit point, because a session can take seconds to come up and the user can background the app mid-start. Committing then would leave a live stream in a backgrounded app with nothing to stop it.

Belt and braces on purpose: even a consumer that ignores the new error code physically cannot reactivate the glasses camera from the background.

## Other details

- Both handlers no-op when nothing is live, so backgrounding an **idle** app doesn't spray terminal `stopped` at anyone subscribed to the state channel.
- The example provider disarms auto-recovery on `stoppedForBackground`. Without it, the SDK's `videoStreamingError` death-rattle races the deliberate stop and the provider restarts the session we just chose to end.

## Verification

- 8/8 Kotlin unit tests pass; example builds clean on both platforms; analyze and format clean.
- **Nothing here is verifiable in CI** — it all needs glasses.

## On-device checks that matter

1. Toggle **off**, stream, background → session closes, placeholder returns, Start re-enables. **Then tap Start: it must succeed.** That last step is the real test — it's what proves the cascade reached the glasses.
2. Repeat 1 five times quickly. A stranded capability often only shows on the Nth restart.
3. Toggle **on**, background, wait 60s, return → preview resumes, no `stopped`.
4. Must **not** stop: Control Center, notification shade, app-switcher peek, call banner. Android: rotation.
5. Background *immediately after* tapping Start → clean `APP_BACKGROUNDED`, never a live background stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)