### PR TITLE
Run CI on every PR, not just those targeting main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,19 @@
 name: CI
 
 on:
+  # No `branches:` filter on purpose. Restricting to `main` meant a PR based on
+  # another branch — every PR in a stack except the bottom one — got no CI at
+  # all. That is not loud: `gh pr checks` prints "no checks reported", which
+  # reads like "nothing failing", and the GitHub UI shows no red. The 0.9.0
+  # background-streaming work shipped as a four-PR stack in which three were
+  # merged-ready with zero validation until they were retargeted one at a time.
   pull_request:
-    branches: [main]
+  # Retargeting a PR fires `pull_request.edited`, which is NOT in the default
+  # trigger set (opened / synchronize / reopened), so changing a base does not
+  # re-run CI. `edited` is deliberately not added here — it also fires on every
+  # title and body edit. Use this manual trigger instead of the close/reopen
+  # dance when you need a re-run without a new commit.
+  workflow_dispatch:
 
 jobs:
   analyze:
@@ -186,7 +197,13 @@ jobs:
   # permanently red check that a contributor cannot fix.
   android-build:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Skipped for fork PRs, which cannot read the GitHub Packages token the
+    # Android build needs. `github.event.pull_request` is null on a manual
+    # dispatch, so without the first clause this job would silently skip on
+    # every `workflow_dispatch` run — a green CI that never built Android.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4


### PR DESCRIPTION
Follow-up from the 0.9.0 stack.

## The problem

`on: pull_request: branches: [main]` meant any PR based on another branch got **no CI at all**. Every PR in a stack except the bottom one was unvalidated.

What makes this worth fixing rather than working around is how quiet it is. `gh pr checks` reports:

```
no checks reported on the 'feat/background-lifecycle-observers' branch
```

which scans as "nothing failing", and the GitHub UI shows no red — just an absence. [#25](https://github.com/rodcone/flutter_meta_wearables_dat/pull/25), [#26](https://github.com/rodcone/flutter_meta_wearables_dat/pull/26) and [#27](https://github.com/rodcone/flutter_meta_wearables_dat/pull/27) all sat merge-ready with zero validation until they were retargeted to `main` one at a time. They passed once run, but that was luck rather than process.

## The fix

Drop the `branches:` filter so every PR is validated regardless of base.

Also adds `workflow_dispatch`, for a second reason found the same day: retargeting a PR fires `pull_request.edited`, which is **not** in the default trigger set (`opened` / `synchronize` / `reopened`). So changing a base doesn't re-run CI, and the only way to get a run without a new commit is closing and reopening the PR. A manual trigger is the civilised version of that.

`edited` is deliberately *not* added to the trigger types — it also fires on every title and body edit, which would burn runs on typo fixes.

## One trap that came with it

The `android-build` fork guard tests `github.event.pull_request.head.repo.full_name`, which is **null** on a manual dispatch. Left alone, that job would have silently skipped on every `workflow_dispatch` run — a green CI that never built Android, which is exactly the class of quiet failure this PR exists to remove. Now allows the dispatch event explicitly.

## Verification

Workflow parses, and the trigger and guard resolve as intended:

```
triggers: ["pull_request", "workflow_dispatch"]
android-build if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
jobs: ["analyze", "test", "dry-run", "versions-in-sync", "pana", "ios-build", "android-build"]
```

This PR targets `main`, so it would have run CI either way — the change proves itself on the next stacked PR. `workflow_dispatch` only becomes available once this is on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)