### PR TITLE
Use the same log tag across all Android files

### DIFF
--- a/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/AppForegroundTracker.kt
+++ b/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/AppForegroundTracker.kt
@@ -123,7 +123,7 @@ internal class AppForegroundTracker(
     }
 
     companion object {
-        private const val TAG = "MWDAT"
+        private const val TAG = "MetaWearablesDat"
         /** Matches `ProcessLifecycleOwner`'s own debounce. */
         const val DEFAULT_DEBOUNCE_MS = 700L
     }


### PR DESCRIPTION
`AppForegroundTracker` logged under `MWDAT` while the other six Android files use `MetaWearablesDat`.

The effect is worse than cosmetic: `adb logcat -s MetaWearablesDat` silently drops the two lines you most need when debugging background behaviour, `lifecycle: app entered background` and `lifecycle: app entered foreground`, while still showing everything around them. So the log looks complete and isn't. I hit this myself writing up the Android QA steps.

Mine, introduced along with the tracker in 0.9.0. One-word change.

Verified: 8/8 Kotlin unit tests, release APK builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)