### PR TITLE
Replace fps double with typed StreamFrameRate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -529,8 +529,8 @@ Develop and test without physical Meta glasses. Mock support lives in the option
 ```yaml
 # pubspec.yaml — add only in dev/staging configs
 dependencies:
-  flutter_meta_wearables_dat: ^0.9.0
-  flutter_meta_wearables_dat_mock_device: ^0.9.0
+  flutter_meta_wearables_dat: ^0.10.0
+  flutter_meta_wearables_dat_mock_device: ^0.10.0
 ```
 
 ```dart

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ static Future<bool> restartActiveDeviceMonitoring()  // No-op on iOS
 // Streaming
 static Future<int> startStreamSession(
   String? deviceId, { // WearableDevice.id (getDevices) pins a pair; null = auto-select
-  double fps = 30.0,
+  StreamFrameRate frameRate = StreamFrameRate.fps30,
   StreamQuality streamQuality = StreamQuality.high,
   VideoCodec videoCodec = VideoCodec.raw,
 })  // Returns textureId. Throws PlatformException 'STREAM_ACTIVE' if a different device is already streaming
@@ -405,7 +405,7 @@ MetaWearablesDat.activeDeviceStream().listen((hasDevice) {
 // Start streaming — returns texture ID for zero-copy rendering
 final textureId = await MetaWearablesDat.startStreamSession(
   null, // null = AutoDeviceSelector (recommended)
-  fps: 24,
+  frameRate: StreamFrameRate.fps24,
   streamQuality: StreamQuality.low,
   videoCodec: VideoCodec.raw,
 );

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Communication:
 | `RegistrationState` | `unavailable(0)`, `available(1)`, `registering(2)`, `registered(3)` |
 | `VideoCodec` | `raw('raw')`, `hvc1('hvc1')` |
 | `StreamQuality` | `high('high')`, `medium('medium')`, `low('low')` |
+| `StreamFrameRate` | `fps2(2)`, `fps7(7)`, `fps15(15)`, `fps24(24)`, `fps30(30)` |
 | `StreamSessionState` | `stopping(0)`, `stopped(1)`, `waitingForDevice(2)`, `starting(3)`, `streaming(4)`, `paused(5)` |
 | `PhotoCaptureFormat` | `heic('heic')`, `jpeg('jpeg')` |
 | `FrameFormat` | `rawRgba`, `rawStraightRgba`, `png` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,11 @@
 ## 0.10.0
 
-Contains contributions by [@kelvinharron](https://github.com/kelvinharron).
-
 **BREAKING CHANGES**
 
 * **`startStreamSession(fps: double)` is now `startStreamSession(frameRate: StreamFrameRate)`.** The DAT SDK accepts exactly five frame rates on both platforms (2, 7, 15, 24, 30) and its behaviour with any other value is undefined; the old `double` let callers request anything. `StreamFrameRate` makes the legal set the type, mirroring `StreamQuality`. Migration: `fps: 24` becomes `frameRate: StreamFrameRate.fps24`; the default is unchanged at 30. Closes [#34](https://github.com/rodcone/flutter_meta_wearables_dat/issues/34).
 * Example app: the frame-rate slider is now a five-way picker driven by `StreamFrameRate.values`.
 
 ## 0.9.1
-
-Contains contributions by [@kelvinharron](https://github.com/kelvinharron).
 
 * **`stopStreamSession()` now ends the whole device session, on both platforms.** The glasses' stream-ended tone hangs off the session lifecycle, so the previous stream-only stop never chimed. Matches Meta's CameraAccess sample and the 0.9.0 background path. Trade-off: the next `startStreamSession()` is a full reconnect rather than a fast re-attach, and the future resolves only once the stop handshake completes.
 * **iOS: `enableBackgroundStreaming()` / `disableBackgroundStreaming()` no longer freeze the UI.** AVAudioSession activation/deactivation block for hundreds of milliseconds and ran inline on the platform thread; all session work now runs on a serial queue, and both futures resolve when the work has actually landed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.10.0
+
+Contains contributions by [@kelvinharron](https://github.com/kelvinharron).
+
+**BREAKING CHANGES**
+
+* **`startStreamSession(fps: double)` is now `startStreamSession(frameRate: StreamFrameRate)`.** The DAT SDK accepts exactly five frame rates on both platforms (2, 7, 15, 24, 30) and its behaviour with any other value is undefined; the old `double` let callers request anything. `StreamFrameRate` makes the legal set the type, mirroring `StreamQuality`. Migration: `fps: 24` becomes `frameRate: StreamFrameRate.fps24`; the default is unchanged at 30. Closes [#34](https://github.com/rodcone/flutter_meta_wearables_dat/issues/34).
+* Example app: the frame-rate slider is now a five-way picker driven by `StreamFrameRate.values`.
+
 ## 0.9.1
 
 Contains contributions by [@kelvinharron](https://github.com/kelvinharron).

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ No app-side platform-channel or native video-rendering code, JPEG encoding, or D
 
 ```yaml
 dependencies:
-  flutter_meta_wearables_dat: ^0.9.0
+  flutter_meta_wearables_dat: ^0.10.0
 ```
 
 ### 2. Configure iOS or Android
@@ -692,8 +692,8 @@ Meta gates registration on real glasses, so during development it's often handy 
 ```yaml
 # pubspec.yaml — add only in dev/staging builds
 dependencies:
-  flutter_meta_wearables_dat: ^0.9.0
-  flutter_meta_wearables_dat_mock_device: ^0.9.0
+  flutter_meta_wearables_dat: ^0.10.0
+  flutter_meta_wearables_dat_mock_device: ^0.10.0
 ```
 
 ```dart

--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ The plugin follows Meta's integration lifecycle as documented in the [Meta Weara
 // getDevices() to stream from a specific pair.
 final textureId = await MetaWearablesDat.startStreamSession(
   null,
-  fps: 24,
+  frameRate: StreamFrameRate.fps24,
   streamQuality: StreamQuality.low,
   videoCodec: VideoCodec.raw, // or VideoCodec.hvc1 (iOS only, supports background streaming)
 );

--- a/agent/claude/skills/camera-streaming.md
+++ b/agent/claude/skills/camera-streaming.md
@@ -29,7 +29,7 @@ final errorSub = MetaWearablesDat.streamSessionErrorStream().listen((error) {
 // Start streaming — returns texture ID
 final textureId = await MetaWearablesDat.startStreamSession(
   null, // null = auto-select; or a WearableDevice.id from getDevices() to pin a pair
-  fps: 24,
+  frameRate: StreamFrameRate.fps24,
   streamQuality: StreamQuality.low,
   videoCodec: VideoCodec.raw,
 );

--- a/agent/claude/skills/mock-device-testing.md
+++ b/agent/claude/skills/mock-device-testing.md
@@ -84,7 +84,7 @@ Streaming, photo capture, registration state, etc. all go through the **core** `
 ```dart
 final textureId = await MetaWearablesDat.startStreamSession(
   deviceUUID,
-  fps: 24,
+  frameRate: StreamFrameRate.fps24,
   streamQuality: StreamQuality.low,
 );
 ```

--- a/agent/claude/skills/mock-device-testing.md
+++ b/agent/claude/skills/mock-device-testing.md
@@ -11,8 +11,8 @@ Since `flutter_meta_wearables_dat` 0.4.0 the mock APIs live in a separate option
 ```yaml
 # pubspec.yaml
 dependencies:
-  flutter_meta_wearables_dat: ^0.9.0
-  flutter_meta_wearables_dat_mock_device: ^0.9.0
+  flutter_meta_wearables_dat: ^0.10.0
+  flutter_meta_wearables_dat_mock_device: ^0.10.0
 ```
 
 ```dart

--- a/agent/cursor/rules/dat-mock-device.mdc
+++ b/agent/cursor/rules/dat-mock-device.mdc
@@ -10,8 +10,8 @@ Mock APIs live in the optional add-on `flutter_meta_wearables_dat_mock_device` (
 ## Add the dev-only dependency
 ```yaml
 dependencies:
-  flutter_meta_wearables_dat: ^0.9.0
-  flutter_meta_wearables_dat_mock_device: ^0.9.0
+  flutter_meta_wearables_dat: ^0.10.0
+  flutter_meta_wearables_dat_mock_device: ^0.10.0
 ```
 
 ```dart

--- a/agent/cursor/rules/dat-mock-device.mdc
+++ b/agent/cursor/rules/dat-mock-device.mdc
@@ -40,7 +40,7 @@ await MetaWearablesDatMockDevice.setCapturedImage(uuid, imagePath);
 ## Stream with mock device
 Streaming + capture still go through the core API. Pass the specific `deviceUUID` (not null):
 ```dart
-final textureId = await MetaWearablesDat.startStreamSession(uuid, fps: 24);
+final textureId = await MetaWearablesDat.startStreamSession(uuid, frameRate: StreamFrameRate.fps24);
 ```
 
 ## Cleanup

--- a/agent/cursor/rules/dat-streaming.mdc
+++ b/agent/cursor/rules/dat-streaming.mdc
@@ -9,7 +9,7 @@ globs: "**/*stream*.dart,**/*video*.dart,**/*camera*.dart,**/*texture*.dart"
 ```dart
 final textureId = await MetaWearablesDat.startStreamSession(
   null, // null = auto-select; or a WearableDevice.id (getDevices()) to pin a pair
-  fps: 24,
+  frameRate: StreamFrameRate.fps24,
   streamQuality: StreamQuality.low,
   videoCodec: VideoCodec.raw,
 );

--- a/agent/github/copilot-instructions.md
+++ b/agent/github/copilot-instructions.md
@@ -38,7 +38,7 @@ All methods are static on `MetaWearablesDat`. Single import: `import 'package:fl
 
 Mock support lives in the optional add-on `flutter_meta_wearables_dat_mock_device` (since 0.4.0). Production builds that omit it skip `MWDATMockDevice` linkage and don't need `NSCameraUsageDescription` / `CAMERA`.
 
-- Add `flutter_meta_wearables_dat_mock_device: ^0.9.0` to dev/staging `pubspec.yaml`.
+- Add `flutter_meta_wearables_dat_mock_device: ^0.10.0` to dev/staging `pubspec.yaml`.
 - Import: `import 'package:flutter_meta_wearables_dat_mock_device/flutter_meta_wearables_dat_mock_device.dart';`
 - Optional bypass for registration/permission flows: `MetaWearablesDatMockDevice.configure(initiallyRegistered: true, initialPermissionsGranted: true)`
 - Lifecycle: `MetaWearablesDatMockDevice.pairGlasses({model})` → UUID (`model` defaults to `GlassesModel.rayBanMeta`; other values: `oakleyMetaHSTN`, `oakleyMetaVanguard`, `rayBanMetaOptics`, `metaGlasses`), then `.powerOn(uuid)` + `.don(uuid)`, optionally `.setCameraFacing(uuid, CameraFacing.back)`

--- a/agent/github/copilot-instructions.md
+++ b/agent/github/copilot-instructions.md
@@ -12,7 +12,7 @@ All methods are static on `MetaWearablesDat`. Single import: `import 'package:fl
 2. `startRegistration()` → user confirms in Meta AI → `handleUrl(url)` deep link callback
 3. `restartActiveDeviceMonitoring()` — call after registration (critical on Android)
 4. `requestCameraPermission()` — Meta AI permission bottom sheet
-5. `startStreamSession(deviceId, fps:, streamQuality:, videoCodec:)` → returns `textureId` — pass a `WearableDevice.id` from `getDevices()` to pin a specific pair, or `null` to auto-select
+5. `startStreamSession(deviceId, frameRate:, streamQuality:, videoCodec:)` → returns `textureId` — pass a `WearableDevice.id` from `getDevices()` to pin a specific pair, or `null` to auto-select
 6. Render: `Texture(textureId: textureId)` — zero-copy GPU rendering
 
 ### Key methods

--- a/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/FrameProcessor.kt
+++ b/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/FrameProcessor.kt
@@ -18,7 +18,7 @@ internal class FrameProcessor {
         private const val TAG = "MetaWearablesDat"
     }
 
-    private var targetFPS: Double = 30.0
+    private var targetFPS: Int = 30
     private var lastFrameSendTime: Long? = null
     private var frameCount: Int = 0
     private var reusableBitmap: Bitmap? = null
@@ -39,7 +39,7 @@ internal class FrameProcessor {
     @Volatile private var released: Boolean = false
     private val lock = Any()
 
-    fun configure(fps: Double) {
+    fun configure(fps: Int) {
         targetFPS = fps
         frameCount = 0
         lastFrameSendTime = null
@@ -75,7 +75,7 @@ internal class FrameProcessor {
         if (released) return
 
         // FPS throttling
-        val minIntervalNanos = (1_000_000_000.0 / targetFPS).toLong()
+        val minIntervalNanos = 1_000_000_000L / targetFPS
         val now = System.nanoTime()
         val lastTime = lastFrameSendTime
         if (lastTime != null && (now - lastTime) < minIntervalNanos) {

--- a/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
+++ b/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
@@ -1150,7 +1150,10 @@ class MetaWearablesDatPlugin :
         }
 
         val args = call.arguments as? Map<*, *>
-        val fps = (args?.get("fps") as? Int) ?: 30
+        // Clamped because the channel stays a public boundary even though the
+        // Dart API is now an enum: zero would throw from the frame throttle's
+        // integer division in FrameProcessor.
+        val fps = ((args?.get("fps") as? Int) ?: 30).coerceAtLeast(1)
         val streamQuality = parseStreamQuality(args?.get("streamQuality") as? String)
         val videoCodec = args?.get("videoCodec") as? String
         val deviceId = args?.get("deviceId") as? String

--- a/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
+++ b/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
@@ -1150,7 +1150,7 @@ class MetaWearablesDatPlugin :
         }
 
         val args = call.arguments as? Map<*, *>
-        val fps = (args?.get("fps") as? Double) ?: 30.0
+        val fps = (args?.get("fps") as? Int) ?: 30
         val streamQuality = parseStreamQuality(args?.get("streamQuality") as? String)
         val videoCodec = args?.get("videoCodec") as? String
         val deviceId = args?.get("deviceId") as? String
@@ -1249,7 +1249,7 @@ class MetaWearablesDatPlugin :
                 }
 
                 sessionKey = key
-                frameProcessor.configure(fps)
+                frameProcessor.configure(fps.toDouble())
 
                 // Register a Flutter texture for zero-copy rendering
                 val registry = textureRegistry
@@ -1284,7 +1284,7 @@ class MetaWearablesDatPlugin :
                 // `Camera` owns the stream.
                 var addedCamera: Camera? = null
                 activeSession
-                        .addCamera(StreamConfiguration(videoQuality = streamQuality, fps.toInt()))
+                        .addCamera(StreamConfiguration(videoQuality = streamQuality, fps))
                         .onSuccess { addedCamera = it }
                         .onFailure { error, _ ->
                             val code =

--- a/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
+++ b/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
@@ -1150,10 +1150,15 @@ class MetaWearablesDatPlugin :
         }
 
         val args = call.arguments as? Map<*, *>
-        // Clamped because the channel stays a public boundary even though the
-        // Dart API is now an enum: zero would throw from the frame throttle's
-        // integer division in FrameProcessor.
-        val fps = ((args?.get("fps") as? Int) ?: 30).coerceAtLeast(1)
+        // The channel stays a boundary the plugin does not control even though
+        // the Dart API is now an enum: zero would throw from the frame
+        // throttle's integer division in FrameProcessor. A non-positive value
+        // falls back to the documented default rather than clamping to 1, which
+        // is not one of the rates Meta documents. Values that are positive but
+        // outside that set are passed through: StreamConfiguration takes a plain
+        // integer, so the legal set lives in StreamFrameRate on the Dart side
+        // and is not duplicated here where nothing keeps it in sync.
+        val fps = (args?.get("fps") as? Int)?.takeIf { it > 0 } ?: 30
         val streamQuality = parseStreamQuality(args?.get("streamQuality") as? String)
         val videoCodec = args?.get("videoCodec") as? String
         val deviceId = args?.get("deviceId") as? String

--- a/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
+++ b/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
@@ -1249,7 +1249,7 @@ class MetaWearablesDatPlugin :
                 }
 
                 sessionKey = key
-                frameProcessor.configure(fps.toDouble())
+                frameProcessor.configure(fps)
 
                 // Register a Flutter texture for zero-copy rendering
                 val registry = textureRegistry

--- a/example/lib/providers/stream_provider.dart
+++ b/example/lib/providers/stream_provider.dart
@@ -22,7 +22,7 @@ class StreamSessionProvider extends ChangeNotifier {
   VideoStreamSize? _videoStreamSize;
   bool _hasActiveDevice = false;
   bool _isStreaming = false;
-  double _fps = 30;
+  StreamFrameRate _frameRate = StreamFrameRate.fps30;
   StreamQuality _streamQuality = StreamQuality.medium;
   VideoCodec _videoCodec = VideoCodec.raw;
   StreamSessionState? _sessionState;
@@ -137,7 +137,7 @@ class StreamSessionProvider extends ChangeNotifier {
 
   bool get hasActiveDevice => _hasActiveDevice;
   bool get isStreaming => _isStreaming;
-  double get fps => _fps;
+  StreamFrameRate get frameRate => _frameRate;
   StreamQuality get streamQuality => _streamQuality;
   VideoCodec get videoCodec => _videoCodec;
   StreamSessionState? get sessionState => _sessionState;
@@ -413,11 +413,11 @@ class StreamSessionProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  void setFps(double fps) {
+  void setFrameRate(StreamFrameRate frameRate) {
     HapticFeedback.lightImpact();
 
-    if (_fps != fps) {
-      _fps = fps;
+    if (_frameRate != frameRate) {
+      _frameRate = frameRate;
       notifyListeners();
     }
   }
@@ -700,7 +700,7 @@ class StreamSessionProvider extends ChangeNotifier {
       // Returns a texture ID for zero-copy rendering via the Flutter Texture widget.
       final textureId = await MetaWearablesDat.startStreamSession(
         _selectedDeviceId,
-        fps: _fps,
+        frameRate: _frameRate,
         streamQuality: _streamQuality,
         videoCodec: _videoCodec,
       );

--- a/example/lib/screens/settings/settings_sheet.dart
+++ b/example/lib/screens/settings/settings_sheet.dart
@@ -75,9 +75,9 @@ class _StreamSettingsSection extends StatelessWidget {
           children: [
             const _SectionTitle(title: 'Stream', icon: Icons.videocam_outlined),
             const SizedBox(height: 16),
-            _FpsSlider(
-              fps: sp.fps,
-              onChanged: locked ? null : sp.setFps,
+            _FrameRatePicker(
+              frameRate: sp.frameRate,
+              onChanged: locked ? null : sp.setFrameRate,
             ),
             const SizedBox(height: 8),
             _ResolutionPicker(
@@ -159,90 +159,43 @@ class _BackgroundStreamingToggle extends StatelessWidget {
   }
 }
 
-class _FpsSlider extends StatelessWidget {
-  final double fps;
-  final ValueChanged<double>? onChanged;
+class _FrameRatePicker extends StatelessWidget {
+  final StreamFrameRate frameRate;
+  final ValueChanged<StreamFrameRate>? onChanged;
 
-  const _FpsSlider({required this.fps, this.onChanged});
-
-  static const List<double> _stops = [2, 7, 15, 24, 30];
-
-  int _closestIndex() {
-    var best = 0;
-    var bestDiff = (fps - _stops[0]).abs();
-    for (var i = 1; i < _stops.length; i++) {
-      final diff = (fps - _stops[i]).abs();
-      if (diff < bestDiff) {
-        bestDiff = diff;
-        best = i;
-      }
-    }
-    return best;
-  }
+  const _FrameRatePicker({required this.frameRate, this.onChanged});
 
   @override
   Widget build(BuildContext context) {
     final enabled = onChanged != null;
     final theme = Theme.of(context);
-    final idx = _closestIndex();
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         _SettingLabel(
           label: 'Frame rate',
-          value: '${_stops[idx].toInt()} fps',
+          value: '${frameRate.value} fps',
           enabled: enabled,
         ),
-        const SizedBox(height: 4),
-        SliderTheme(
-          data: SliderTheme.of(context).copyWith(
-            trackHeight: 4,
-            thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 8),
-            overlayShape: const RoundSliderOverlayShape(overlayRadius: 18),
-            tickMarkShape: const RoundSliderTickMarkShape(tickMarkRadius: 3),
-            activeTrackColor: enabled
-                ? theme.colorScheme.primary
-                : theme.colorScheme.onSurface.withOpacity(0.12),
-            inactiveTrackColor: theme.colorScheme.onSurface.withOpacity(0.08),
-            thumbColor: enabled
-                ? theme.colorScheme.primary
-                : theme.colorScheme.onSurface.withOpacity(0.3),
-            activeTickMarkColor: theme.colorScheme.onPrimary,
-            inactiveTickMarkColor: theme.colorScheme.onSurface.withOpacity(0.2),
-          ),
-          child: Slider(
-            value: idx.toDouble(),
-            max: (_stops.length - 1).toDouble(),
-            divisions: _stops.length - 1,
-            onChanged: enabled
-                ? (v) {
-                    HapticFeedback.selectionClick();
-                    onChanged!(_stops[v.round()]);
-                  }
-                : null,
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: _stops.map((s) {
-              final isSelected = s == _stops[idx];
-              return Text(
-                '${s.toInt()}',
-                style: TextStyle(
-                  fontSize: 11,
-                  fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
-                  color: enabled
-                      ? (isSelected
-                            ? theme.colorScheme.primary
-                            : theme.colorScheme.onSurface.withOpacity(0.45))
-                      : theme.colorScheme.onSurface.withOpacity(0.25),
+        const SizedBox(height: 8),
+        Row(
+          children: StreamFrameRate.values.map((rate) {
+            final isLast = rate == StreamFrameRate.values.last;
+            return Expanded(
+              child: Padding(
+                padding: EdgeInsets.only(right: isLast ? 0 : 8),
+                child: _ResolutionChip(
+                  label: '${rate.value}',
+                  subtitle: 'fps',
+                  selected: rate == frameRate,
+                  enabled: enabled,
+                  onTap: enabled ? () => onChanged!(rate) : null,
+                  theme: theme,
                 ),
-              );
-            }).toList(),
-          ),
+              ),
+            );
+          }).toList(),
         ),
       ],
     );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -204,14 +204,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.9.1"
+    version: "0.10.0"
   flutter_meta_wearables_dat_mock_device:
     dependency: "direct main"
     description:
       path: "../flutter_meta_wearables_dat_mock_device"
       relative: true
     source: path
-    version: "0.9.1"
+    version: "0.10.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:

--- a/flutter_meta_wearables_dat_mock_device/CHANGELOG.md
+++ b/flutter_meta_wearables_dat_mock_device/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.0
+
+* Align version with core package's 0.10.0 release. No API changes in this package. Note the core release replaces `startStreamSession(fps: double)` with `frameRate: StreamFrameRate`, which also applies to mock-backed streams.
+
 ## 0.9.1
 
 * Align version with core package's 0.9.1 release. No API changes. Note the core release changes `stopStreamSession()` to end the whole device session (glasses chime; next start is a full reconnect) — mock-backed streams follow the same path.

--- a/flutter_meta_wearables_dat_mock_device/README.md
+++ b/flutter_meta_wearables_dat_mock_device/README.md
@@ -14,8 +14,8 @@ Optional **MockDeviceKit** add-on for [`flutter_meta_wearables_dat`](https://pub
 ```yaml
 # pubspec.yaml
 dependencies:
-  flutter_meta_wearables_dat: ^0.9.0
-  flutter_meta_wearables_dat_mock_device: ^0.9.0
+  flutter_meta_wearables_dat: ^0.10.0
+  flutter_meta_wearables_dat_mock_device: ^0.10.0
 ```
 
 Apps using this package **must** declare the camera permission strings the simulated feed needs:

--- a/flutter_meta_wearables_dat_mock_device/ios/flutter_meta_wearables_dat_mock_device.podspec
+++ b/flutter_meta_wearables_dat_mock_device/ios/flutter_meta_wearables_dat_mock_device.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_meta_wearables_dat_mock_device'
-  s.version          = '0.9.1'
+  s.version          = '0.10.0'
   s.summary          = 'Optional MockDeviceKit add-on for flutter_meta_wearables_dat.'
   s.description      = <<-DESC
 Optional MockDeviceKit add-on for flutter_meta_wearables_dat. Pull this in only

--- a/flutter_meta_wearables_dat_mock_device/pubspec.yaml
+++ b/flutter_meta_wearables_dat_mock_device/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_meta_wearables_dat_mock_device
 description: "Optional MockDeviceKit add-on for flutter_meta_wearables_dat — simulate Meta glasses using the phone's camera for development and testing. Omit in production."
-version: 0.9.1
+version: 0.10.0
 repository: https://github.com/rodcone/flutter_meta_wearables_dat
 
 environment:

--- a/ios/flutter_meta_wearables_dat.podspec
+++ b/ios/flutter_meta_wearables_dat.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_meta_wearables_dat'
-  s.version          = '0.9.1'
+  s.version          = '0.10.0'
   s.summary          = "Flutter bridge to Meta's Wearables DAT for iOS and Android."
   s.description      = <<-DESC
 Flutter plugin providing a bridge to Meta's Wearables Device Access Toolkit (DAT)

--- a/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/MetaWearablesDatPlugin.swift
+++ b/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/MetaWearablesDatPlugin.swift
@@ -1664,7 +1664,10 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
       return
     }
 
-    let fps = (args["fps"] as? Int) ?? 30
+    // Clamped because the channel stays a public boundary even though the Dart
+    // API is now an enum: a negative value would trap in `UInt(_:)` below, and
+    // zero would stall the frame throttle at an infinite interval.
+    let fps = max(1, (args["fps"] as? Int) ?? 30)
     let streamQuality = Self.parseStreamQuality(args["streamQuality"] as? String)
     let videoCodecStr = args["videoCodec"] as? String ?? "raw"
     let videoCodec: MWDATCamera.VideoCodec = (videoCodecStr == "hvc1") ? .hvc1 : .raw

--- a/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/MetaWearablesDatPlugin.swift
+++ b/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/MetaWearablesDatPlugin.swift
@@ -119,7 +119,7 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
   private var teardownTask: Task<Void, Never>?
   private var teardownSeq = 0
   private var frameCounter: Int = 0
-  private var currentTargetFPS: Double = 30.0
+  private var currentTargetFPS: Int = 30
   private var lastFrameSendTime: Date?
   private var pixelBufferTexture: PixelBufferTexture?
   private var textureId: Int64?
@@ -1280,7 +1280,7 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
     videoStreamSizeHandler.send(width: width, height: height)
 
     let now = Date()
-    let minInterval = 1.0 / currentTargetFPS
+    let minInterval = 1.0 / Double(currentTargetFPS)
 
     let timeSinceLastFrame: TimeInterval
     if let lastSendTime = lastFrameSendTime {
@@ -1773,7 +1773,7 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
       let texId = registry.register(texture)
       pixelBufferTexture = texture
       textureId = texId
-      currentTargetFPS = Double(fps)
+      currentTargetFPS = fps
       currentVideoCodec = videoCodec
       frameCounter = 0
       lastFrameSendTime = nil

--- a/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/MetaWearablesDatPlugin.swift
+++ b/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/MetaWearablesDatPlugin.swift
@@ -1664,10 +1664,15 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
       return
     }
 
-    // Clamped because the channel stays a public boundary even though the Dart
-    // API is now an enum: a negative value would trap in `UInt(_:)` below, and
-    // zero would stall the frame throttle at an infinite interval.
-    let fps = max(1, (args["fps"] as? Int) ?? 30)
+    // The channel stays a boundary the plugin does not control even though the
+    // Dart API is now an enum: a negative value would trap in `UInt(_:)` below,
+    // and zero would stall the frame throttle at an infinite interval. A
+    // non-positive value falls back to the documented default rather than
+    // clamping to 1, which is not one of the rates Meta documents. Values that
+    // are positive but outside that set are passed through: `StreamConfiguration`
+    // takes a plain integer, so the legal set lives in `StreamFrameRate` on the
+    // Dart side and is not duplicated here where nothing keeps it in sync.
+    let fps = (args["fps"] as? Int).flatMap { $0 > 0 ? $0 : nil } ?? 30
     let streamQuality = Self.parseStreamQuality(args["streamQuality"] as? String)
     let videoCodecStr = args["videoCodec"] as? String ?? "raw"
     let videoCodec: MWDATCamera.VideoCodec = (videoCodecStr == "hvc1") ? .hvc1 : .raw

--- a/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/MetaWearablesDatPlugin.swift
+++ b/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/MetaWearablesDatPlugin.swift
@@ -1664,7 +1664,7 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
       return
     }
 
-    let fps = (args["fps"] as? Double) ?? 30.0
+    let fps = (args["fps"] as? Int) ?? 30
     let streamQuality = Self.parseStreamQuality(args["streamQuality"] as? String)
     let videoCodecStr = args["videoCodec"] as? String ?? "raw"
     let videoCodec: MWDATCamera.VideoCodec = (videoCodecStr == "hvc1") ? .hvc1 : .raw
@@ -1773,7 +1773,7 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
       let texId = registry.register(texture)
       pixelBufferTexture = texture
       textureId = texId
-      currentTargetFPS = fps
+      currentTargetFPS = Double(fps)
       currentVideoCodec = videoCodec
       frameCounter = 0
       lastFrameSendTime = nil
@@ -1781,11 +1781,10 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
 
       // 3. Add a Camera capability. DAT 0.9.0 replaced `addStream` with
       // `addCamera`; the returned `Camera` owns the stream.
-      let fpsValue = UInt(max(1, Int(fps.rounded())))
       let streamConfig = StreamConfiguration(
         videoCodec: videoCodec,
         resolution: Self.resolution(for: streamQuality),
-        frameRate: fpsValue
+        frameRate: UInt(fps)
       )
 
       let newCamera: MWDATCamera.Camera?

--- a/lib/flutter_meta_wearables_dat.dart
+++ b/lib/flutter_meta_wearables_dat.dart
@@ -71,6 +71,25 @@ enum StreamQuality {
   final String value;
 }
 
+/// Frame rates the DAT SDK accepts for a camera stream.
+///
+/// Meta documents exactly these five values for both platforms; the SDK's
+/// behaviour with any other value is undefined. Under constrained Bluetooth
+/// bandwidth the SDK steps the rate down on its own (30 to 24) but never
+/// below 15.
+enum StreamFrameRate {
+  fps2(2),
+  fps7(7),
+  fps15(15),
+  fps24(24),
+  fps30(30);
+
+  const StreamFrameRate(this.value);
+
+  /// Frames per second sent over the platform channel.
+  final int value;
+}
+
 /// Represents the current state of a stream session.
 enum StreamSessionState {
   /// The session is in the process of stopping.
@@ -752,18 +771,18 @@ class MetaWearablesDat {
   /// already running on a *different* device — stop it first, then start.
   static Future<int> startStreamSession(
     String? deviceId, {
-    double fps = 30.0,
+    StreamFrameRate frameRate = StreamFrameRate.fps30,
     StreamQuality streamQuality = StreamQuality.high,
     VideoCodec videoCodec = VideoCodec.raw,
   }) {
     if (kDebugMode) {
       debugPrint(
-        '[MetaWearablesDAT] Starting stream session with deviceId: $deviceId, FPS: $fps, Stream quality: $streamQuality, Video codec: $videoCodec',
+        '[MetaWearablesDAT] Starting stream session with deviceId: $deviceId, FPS: ${frameRate.value}, Stream quality: $streamQuality, Video codec: $videoCodec',
       );
     }
     return MetaWearablesDatPlatform.instance.startStreamSession(
       deviceId,
-      fps: fps,
+      frameRate: frameRate,
       streamQuality: streamQuality,
       videoCodec: videoCodec,
     );

--- a/lib/meta_wearables_dat_method_channel.dart
+++ b/lib/meta_wearables_dat_method_channel.dart
@@ -123,12 +123,12 @@ class MethodChannelMetaWearablesDat extends MetaWearablesDatPlatform {
   @override
   Future<int> startStreamSession(
     String? deviceId, {
-    double fps = 30.0,
+    StreamFrameRate frameRate = StreamFrameRate.fps30,
     StreamQuality streamQuality = StreamQuality.high,
     VideoCodec videoCodec = VideoCodec.raw,
   }) async {
     final args = <String, dynamic>{
-      'fps': fps,
+      'fps': frameRate.value,
       'streamQuality': streamQuality.value,
       'videoCodec': videoCodec.value,
     };

--- a/lib/meta_wearables_dat_platform_interface.dart
+++ b/lib/meta_wearables_dat_platform_interface.dart
@@ -61,7 +61,7 @@ abstract class MetaWearablesDatPlatform extends PlatformInterface {
   /// via the Flutter `Texture` widget (zero-copy path).
   Future<int> startStreamSession(
     String? deviceId, {
-    double fps = 30.0,
+    StreamFrameRate frameRate = StreamFrameRate.fps30,
     StreamQuality streamQuality = StreamQuality.high,
     VideoCodec videoCodec = VideoCodec.raw,
   }) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_meta_wearables_dat
 description: "Flutter bridge to Meta's Wearables DAT for iOS and Android."
-version: 0.9.1
+version: 0.10.0
 repository: https://github.com/rodcone/flutter_meta_wearables_dat
 
 environment:

--- a/test/start_stream_session_pinning_test.dart
+++ b/test/start_stream_session_pinning_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/services.dart';
+import 'package:flutter_meta_wearables_dat/flutter_meta_wearables_dat.dart';
 import 'package:flutter_meta_wearables_dat/meta_wearables_dat_method_channel.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -42,6 +43,22 @@ void main() {
 
     expect(captured, isNotNull);
     expect(captured!.containsKey('deviceId'), isFalse);
+  });
+
+  test('startStreamSession forwards frameRate as an int under "fps"', () async {
+    Map<Object?, Object?>? captured;
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      captured = call.arguments as Map<Object?, Object?>;
+      return 1;
+    });
+
+    await platform.startStreamSession(null, frameRate: StreamFrameRate.fps24);
+
+    // The wire type matters as much as the value: Kotlin's `as? Int` does no
+    // numeric coercion, so a regression to a double would make Android fall
+    // back to its 30 fps default silently instead of failing.
+    expect(captured?['fps'], 24);
+    expect(captured?['fps'], isA<int>());
   });
 
   test('startStreamSession propagates a STREAM_ACTIVE PlatformException', () {


### PR DESCRIPTION
# Description

Addressees #34 

* Replace double usage for fps with explicit types at dart level to prevent passing invalid values. Tested on iOS using the updated example app as a reference