### PR TITLE
ci: check that doc install snippets admit the current version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,96 @@ jobs:
           fi
           echo "OK: all four version locations are at $CORE_PUBSPEC"
 
+      # The install snippets in README / AGENTS / the agent rule files are a
+      # fifth version location, and until now nothing read them. `^0.9.0`
+      # resolves to >=0.9.0 <0.10.0, so a *minor* bump silently leaves every
+      # snippet pinning users to a release without the new API — 0.10.0 reached
+      # review that way, with the README telling users to install a version its
+      # own streaming example could not compile against.
+      #
+      # The rule is caret containment, not equality: `^0.9.0` legitimately
+      # admits 0.9.1, so patch releases need no doc churn. Docs are discovered
+      # by glob rather than a fixed list, so a newly added agent file is covered
+      # automatically; changelogs are skipped because their historical entries
+      # legitimately quote old constraints.
+      - name: Verify doc install snippets admit the current version
+        run: |
+          python3 - <<'CHECK_SNIPPETS'
+          import re, sys, pathlib
+
+          PKGS = {
+              'flutter_meta_wearables_dat': 'pubspec.yaml',
+              'flutter_meta_wearables_dat_mock_device':
+                  'flutter_meta_wearables_dat_mock_device/pubspec.yaml',
+          }
+
+          def core(v, where):
+              m = re.match(r'(\d+)\.(\d+)\.(\d+)', v)
+              if not m:
+                  sys.exit(f'::error::unparseable version {v!r} in {where}')
+              return tuple(int(g) for g in m.groups())
+
+          def caret_upper(v):
+              """Upper bound of pub's `^v`, matching dart.dev/tools/pub/dependencies."""
+              x, y, z = v
+              if x > 0:
+                  return (x + 1, 0, 0)
+              if y > 0:
+                  return (0, y + 1, 0)
+              return (0, 0, z + 1)
+
+          versions = {}
+          for pkg, path in PKGS.items():
+              txt = pathlib.Path(path).read_text()
+              versions[pkg] = core(re.search(r'^version:\s*(\S+)', txt, re.M).group(1), path)
+
+          # Scan every doc rather than a hardcoded file list, so a newly added agent
+          # file is covered automatically. Changelogs are excluded: their historical
+          # entries legitimately quote old constraints.
+          files = [
+              p for p in sorted([*pathlib.Path('.').rglob('*.md'), *pathlib.Path('.').rglob('*.mdc')])
+              if 'CHANGELOG' not in p.name
+              and not any(part in ('build', '.dart_tool', '.git') for part in p.parts)
+          ]
+
+          pattern = re.compile(
+              r'\b(flutter_meta_wearables_dat(?:_mock_device)?)\b\s*:\s*\^(\d+\.\d+\.\d+)')
+
+          stale, checked = [], 0
+          for p in files:
+              for lineno, line in enumerate(p.read_text().splitlines(), 1):
+                  for m in pattern.finditer(line):
+                      pkg, snippet = m.group(1), m.group(2)
+                      if pkg not in versions:
+                          continue
+                      checked += 1
+                      lo = core(snippet, p)
+                      hi = caret_upper(lo)
+                      actual = versions[pkg]
+                      if not (lo <= actual < hi):
+                          stale.append(
+                              f'{p}:{lineno}: ^{snippet} does not admit '
+                              f'{".".join(map(str, actual))} ({pkg})')
+
+          for pkg, v in versions.items():
+              print(f'  {pkg}: {".".join(map(str, v))}')
+          print(f'  checked {checked} constraint(s) across {len(files)} doc file(s)')
+
+          # A pattern that matches nothing must fail, not pass silently: a docs reformat
+          # would otherwise leave this job green while covering zero constraints.
+          if checked == 0:
+              sys.exit('::error::no install snippets matched — the pattern has drifted')
+
+          if stale:
+              print('\nStale install snippets (a user following these installs a release '
+                    'without the current API):')
+              for s in stale:
+                  print(f'::error::{s}')
+              sys.exit(1)
+
+          print('OK: every install snippet admits the current version')
+          CHECK_SNIPPETS
+
   # Gate on a perfect pub.dev score for both packages. pana is the analyzer
   # behind pub.dev's "pub points"; --exit-code-threshold 0 fails the job when
   # any points are lost (max - granted > 0), so every release stays at

--- a/doc/MAINTAINERS.md
+++ b/doc/MAINTAINERS.md
@@ -195,15 +195,21 @@ Before tagging, confirm:
    - `ios/flutter_meta_wearables_dat.podspec` (`s.version`)
    - `flutter_meta_wearables_dat_mock_device/pubspec.yaml`
    - `flutter_meta_wearables_dat_mock_device/ios/flutter_meta_wearables_dat_mock_device.podspec` (`s.version`)
-2. **If this release bumps the DAT SDK:** all three iOS xcframeworks are updated (`MWDATCore` + `MWDATCamera` in the core plugin **and** `MWDATMockDevice` in the mock add-on), `./scripts/thin-xcframeworks.sh` has been run, and both Android `ext.mwdat_version` values match.
-3. **Both `CHANGELOG.md` files have a `## <new-version>` entry.** The publish workflow's `github-release` job extracts these for the GitHub release notes — missing entries produce an empty release body.
-4. **Both packages are clean locally:**
+2. **The install snippets admit the new version.** `README.md`, `AGENTS.md`,
+   `flutter_meta_wearables_dat_mock_device/README.md` and the `agent/` rule
+   files all carry `flutter_meta_wearables_dat: ^<x>.<y>.0` blocks. A caret on
+   a `0.x` version excludes the next minor, so a minor bump must update them or
+   the docs install a release without the new API. Patch bumps need no change.
+   The `versions-in-sync` CI job enforces this.
+3. **If this release bumps the DAT SDK:** all three iOS xcframeworks are updated (`MWDATCore` + `MWDATCamera` in the core plugin **and** `MWDATMockDevice` in the mock add-on), `./scripts/thin-xcframeworks.sh` has been run, and both Android `ext.mwdat_version` values match.
+4. **Both `CHANGELOG.md` files have a `## <new-version>` entry.** The publish workflow's `github-release` job extracts these for the GitHub release notes — missing entries produce an empty release body.
+5. **Both packages are clean locally:**
    ```bash
    dart analyze && (cd flutter_meta_wearables_dat_mock_device && dart analyze)
    dart pub publish --dry-run && (cd flutter_meta_wearables_dat_mock_device && dart pub publish --dry-run)
    ```
-5. **The example app still builds** — `cd example && flutter build ios --release --no-codesign` and `flutter build apk --release`.
-6. **You're tagging from `main` with no uncommitted changes.** Tags are not branch-scoped on push; whatever commit you tag is what gets published.
+6. **The example app still builds** — `cd example && flutter build ios --release --no-codesign` and `flutter build apk --release`.
+7. **You're tagging from `main` with no uncommitted changes.** Tags are not branch-scoped on push; whatever commit you tag is what gets published.
 
 ### Steps
 


### PR DESCRIPTION
## Why

The install snippets in `README.md`, `AGENTS.md` and the `agent/` rule files are a **fifth version location**, and nothing in CI read them.

`^0.9.0` resolves to `>=0.9.0 <0.10.0`, so a *minor* bump silently leaves every snippet pinning users to a release without the new API. PR #35 reached review exactly that way: the README told users to install `^0.9.0` while its own streaming example used `frameRate:`, which only exists in 0.10.0. Twelve stale lines across six files, and `versions-in-sync` only reads the two pubspecs and the two podspecs.

## What

A second step in the existing `versions-in-sync` job, plus the matching entry in the `doc/MAINTAINERS.md` pre-flight checklist.

Design notes:

- **Caret containment, not equality.** `^0.9.0` legitimately admits 0.9.1, so patch releases need no doc churn — only minor and major bumps do. This is why the check passes on `main` as-is.
- **Files are found by glob**, so a newly added agent file is covered without editing this job.
- **Changelogs are skipped** — their historical entries legitimately quote old constraints.
- **Matching zero snippets fails.** A docs reformat would otherwise leave the job green while checking nothing, the same trap as a `NO-SOURCE` Gradle task.

## Verification

The step's own script was extracted from the parsed workflow and run against three real trees:

| Tree | Expected | Result |
|---|---|---|
| `main` (0.9.1 vs `^0.9.0`) | pass | exit 0 |
| PR #35 at `080c7ce` (0.10.0 vs `^0.9.0`) | fail | exit 1, all 12 locations reported |
| PR #35 head (0.10.0 vs `^0.10.0`) | pass | exit 0 |
| pattern matches nothing | fail | exit 1 |

Independent of #35 and mergeable in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)