### PR TITLE
release: 0.9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,9 +126,10 @@ jobs:
       # The install snippets in README / AGENTS / the agent rule files are a
       # fifth version location, and until now nothing read them. `^0.9.0`
       # resolves to >=0.9.0 <0.10.0, so a *minor* bump silently leaves every
-      # snippet pinning users to a release without the new API — 0.10.0 reached
-      # review that way, with the README telling users to install a version its
-      # own streaming example could not compile against.
+      # snippet pinning users to a release without the new API. The
+      # StreamFrameRate work reached review that way, with the README telling
+      # users to install a version its own streaming example could not compile
+      # against.
       #
       # The rule is caret containment, not equality: `^0.9.0` legitimately
       # admits 0.9.1, so patch releases need no doc churn. Docs are discovered

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -529,8 +529,8 @@ Develop and test without physical Meta glasses. Mock support lives in the option
 ```yaml
 # pubspec.yaml — add only in dev/staging configs
 dependencies:
-  flutter_meta_wearables_dat: ^0.10.0
-  flutter_meta_wearables_dat_mock_device: ^0.10.0
+  flutter_meta_wearables_dat: ^0.9.2
+  flutter_meta_wearables_dat_mock_device: ^0.9.2
 ```
 
 ```dart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 0.10.0
+## 0.9.2
 
-**BREAKING CHANGES**
+**BREAKING CHANGES** — note these ship in a *patch* release. A constraint of
+`^0.9.0` or `^0.9.1` resolves to this version on `pub upgrade`, so pin
+`flutter_meta_wearables_dat: 0.9.1` if you are not ready to migrate.
 
 * **`startStreamSession(fps: double)` is now `startStreamSession(frameRate: StreamFrameRate)`.** The DAT SDK accepts exactly five frame rates on both platforms (2, 7, 15, 24, 30) and its behaviour with any other value is undefined; the old `double` let callers request anything. `StreamFrameRate` makes the legal set the type, mirroring `StreamQuality`. Migration: `fps: 24` becomes `frameRate: StreamFrameRate.fps24`; the default is unchanged at 30. Closes [#34](https://github.com/rodcone/flutter_meta_wearables_dat/issues/34).
 * Example app: the frame-rate slider is now a five-way picker driven by `StreamFrameRate.values`.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ No app-side platform-channel or native video-rendering code, JPEG encoding, or D
 
 ```yaml
 dependencies:
-  flutter_meta_wearables_dat: ^0.10.0
+  flutter_meta_wearables_dat: ^0.9.2
 ```
 
 ### 2. Configure iOS or Android
@@ -692,8 +692,8 @@ Meta gates registration on real glasses, so during development it's often handy 
 ```yaml
 # pubspec.yaml — add only in dev/staging builds
 dependencies:
-  flutter_meta_wearables_dat: ^0.10.0
-  flutter_meta_wearables_dat_mock_device: ^0.10.0
+  flutter_meta_wearables_dat: ^0.9.2
+  flutter_meta_wearables_dat_mock_device: ^0.9.2
 ```
 
 ```dart

--- a/agent/claude/skills/mock-device-testing.md
+++ b/agent/claude/skills/mock-device-testing.md
@@ -11,8 +11,8 @@ Since `flutter_meta_wearables_dat` 0.4.0 the mock APIs live in a separate option
 ```yaml
 # pubspec.yaml
 dependencies:
-  flutter_meta_wearables_dat: ^0.10.0
-  flutter_meta_wearables_dat_mock_device: ^0.10.0
+  flutter_meta_wearables_dat: ^0.9.2
+  flutter_meta_wearables_dat_mock_device: ^0.9.2
 ```
 
 ```dart

--- a/agent/cursor/rules/dat-mock-device.mdc
+++ b/agent/cursor/rules/dat-mock-device.mdc
@@ -10,8 +10,8 @@ Mock APIs live in the optional add-on `flutter_meta_wearables_dat_mock_device` (
 ## Add the dev-only dependency
 ```yaml
 dependencies:
-  flutter_meta_wearables_dat: ^0.10.0
-  flutter_meta_wearables_dat_mock_device: ^0.10.0
+  flutter_meta_wearables_dat: ^0.9.2
+  flutter_meta_wearables_dat_mock_device: ^0.9.2
 ```
 
 ```dart

--- a/agent/github/copilot-instructions.md
+++ b/agent/github/copilot-instructions.md
@@ -38,7 +38,7 @@ All methods are static on `MetaWearablesDat`. Single import: `import 'package:fl
 
 Mock support lives in the optional add-on `flutter_meta_wearables_dat_mock_device` (since 0.4.0). Production builds that omit it skip `MWDATMockDevice` linkage and don't need `NSCameraUsageDescription` / `CAMERA`.
 
-- Add `flutter_meta_wearables_dat_mock_device: ^0.10.0` to dev/staging `pubspec.yaml`.
+- Add `flutter_meta_wearables_dat_mock_device: ^0.9.2` to dev/staging `pubspec.yaml`.
 - Import: `import 'package:flutter_meta_wearables_dat_mock_device/flutter_meta_wearables_dat_mock_device.dart';`
 - Optional bypass for registration/permission flows: `MetaWearablesDatMockDevice.configure(initiallyRegistered: true, initialPermissionsGranted: true)`
 - Lifecycle: `MetaWearablesDatMockDevice.pairGlasses({model})` → UUID (`model` defaults to `GlassesModel.rayBanMeta`; other values: `oakleyMetaHSTN`, `oakleyMetaVanguard`, `rayBanMetaOptics`, `metaGlasses`), then `.powerOn(uuid)` + `.don(uuid)`, optionally `.setCameraFacing(uuid, CameraFacing.back)`

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -204,14 +204,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.10.0"
+    version: "0.9.2"
   flutter_meta_wearables_dat_mock_device:
     dependency: "direct main"
     description:
       path: "../flutter_meta_wearables_dat_mock_device"
       relative: true
     source: path
-    version: "0.10.0"
+    version: "0.9.2"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:

--- a/flutter_meta_wearables_dat_mock_device/CHANGELOG.md
+++ b/flutter_meta_wearables_dat_mock_device/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.10.0
+## 0.9.2
 
-* Align version with core package's 0.10.0 release. No API changes in this package. Note the core release replaces `startStreamSession(fps: double)` with `frameRate: StreamFrameRate`, which also applies to mock-backed streams.
+* Align version with core package's 0.9.2 release. No API changes in this package. Note the core release replaces `startStreamSession(fps: double)` with `frameRate: StreamFrameRate`, which also applies to mock-backed streams.
 
 ## 0.9.1
 

--- a/flutter_meta_wearables_dat_mock_device/README.md
+++ b/flutter_meta_wearables_dat_mock_device/README.md
@@ -14,8 +14,8 @@ Optional **MockDeviceKit** add-on for [`flutter_meta_wearables_dat`](https://pub
 ```yaml
 # pubspec.yaml
 dependencies:
-  flutter_meta_wearables_dat: ^0.10.0
-  flutter_meta_wearables_dat_mock_device: ^0.10.0
+  flutter_meta_wearables_dat: ^0.9.2
+  flutter_meta_wearables_dat_mock_device: ^0.9.2
 ```
 
 Apps using this package **must** declare the camera permission strings the simulated feed needs:

--- a/flutter_meta_wearables_dat_mock_device/ios/flutter_meta_wearables_dat_mock_device.podspec
+++ b/flutter_meta_wearables_dat_mock_device/ios/flutter_meta_wearables_dat_mock_device.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_meta_wearables_dat_mock_device'
-  s.version          = '0.10.0'
+  s.version          = '0.9.2'
   s.summary          = 'Optional MockDeviceKit add-on for flutter_meta_wearables_dat.'
   s.description      = <<-DESC
 Optional MockDeviceKit add-on for flutter_meta_wearables_dat. Pull this in only

--- a/flutter_meta_wearables_dat_mock_device/pubspec.yaml
+++ b/flutter_meta_wearables_dat_mock_device/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_meta_wearables_dat_mock_device
 description: "Optional MockDeviceKit add-on for flutter_meta_wearables_dat — simulate Meta glasses using the phone's camera for development and testing. Omit in production."
-version: 0.10.0
+version: 0.9.2
 repository: https://github.com/rodcone/flutter_meta_wearables_dat
 
 environment:

--- a/ios/flutter_meta_wearables_dat.podspec
+++ b/ios/flutter_meta_wearables_dat.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_meta_wearables_dat'
-  s.version          = '0.10.0'
+  s.version          = '0.9.2'
   s.summary          = "Flutter bridge to Meta's Wearables DAT for iOS and Android."
   s.description      = <<-DESC
 Flutter plugin providing a bridge to Meta's Wearables Device Access Toolkit (DAT)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_meta_wearables_dat
 description: "Flutter bridge to Meta's Wearables DAT for iOS and Android."
-version: 0.10.0
+version: 0.9.2
 repository: https://github.com/rodcone/flutter_meta_wearables_dat
 
 environment:


### PR DESCRIPTION
Renumbers the `StreamFrameRate` release from `0.10.0` to `0.9.2`.

## Changed

- All four version locations: both `pubspec.yaml`, both `.podspec`
- Both `CHANGELOG.md` headings, plus the mock package's cross-reference to the core release
- The twelve doc install snippets → `^0.9.2`
- `example/pubspec.lock` path-dep versions
- Drops `0.10.0` from the install-snippet CI comment, which would otherwise cite a version that never shipped

Deliberately **not** touched: `.claude/skills/dat-update/` still mentions `0.10.0`, but as a *DAT SDK* version example, unrelated to the package version.

## Semver note

The API change in this release is breaking — `startStreamSession(fps: double)` was removed. A patch number does not signal that, and `^0.9.0` / `^0.9.1` both resolve to `0.9.2`, so existing callers pick it up on `pub upgrade` and stop compiling on `fps:`.

Shipping it as a patch is a deliberate maintainer decision. Since the version number can't carry the warning, the changelog entry now does:

> **BREAKING CHANGES** — note these ship in a *patch* release. A constraint of `^0.9.0` or `^0.9.1` resolves to this version on `pub upgrade`, so pin `flutter_meta_wearables_dat: 0.9.1` if you are not ready to migrate.

## Pre-flight (doc/MAINTAINERS.md)

| # | Item | Result |
|---|---|---|
| 1 | Four version locations match | all `0.9.2` |
| 2 | Install snippets admit the version | all `^0.9.2`, new CI check green |
| 3 | DAT SDK bump | N/A — still DAT 0.9.0, both Gradle files agree |
| 4 | Both CHANGELOGs have the entry | `## 0.9.2` in both |
| 5 | Both packages clean | analyze clean, 20 + 4 tests pass, **publish dry-run 0 warnings both** |
| 6 | Example builds both platforms | APK release 66.2MB, iOS release 59.8MB |
| 7 | Tag from main, clean tree | after merge |

🤖 Generated with [Claude Code](https://claude.com/claude-code)