### PR TITLE
ci: pin Flutter in the publish workflow to 3.47.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,30 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
+      # Flutter is PINNED here, unlike ci.yml which floats on `stable`.
+      #
+      # On Flutter 3.47.3 this job's first `flutter pub get` fails, three runs
+      # for three, with:
+      #
+      #   Because flutter_tools depends on test 1.31.1 which doesn't match any
+      #   versions, version solving failed.
+      #
+      # `test 1.31.1` is published and not retracted, and the same commit
+      # resolves fine in ci.yml on the very same Flutter 3.47.3 with a cold
+      # SDK — the difference is that this job also runs setup-dart. The
+      # interaction is not understood; what is established is that Flutter
+      # 3.47.1 + setup-dart published this repo successfully (v0.9.1,
+      # 2026-08-26, same workflow otherwise unchanged), so this pins the
+      # configuration with direct evidence rather than guessing at a cause.
+      #
+      # Publishing is irreversible, so a deterministic Flutter here is a
+      # feature, not just a workaround. Revisit when a later stable resolves
+      # cleanly alongside setup-dart; verify by re-running this workflow on a
+      # throwaway tag before bumping.
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: 3.47.1
 
       # Both packages publish in lockstep — verify the tag matches *both*
       # pubspecs before doing anything destructive.


### PR DESCRIPTION
Unblocks the `v0.9.2` release, which has failed three publish runs at the job's first `flutter pub get`:

```
Because flutter_tools depends on test 1.31.1 which doesn't match any versions, version solving failed.
```

## What the evidence rules out

| Hypothesis | Verdict |
|---|---|
| Transient pub.dev flake | **No** — same package named 3/3 runs |
| `test 1.31.1` unpublished or retracted | **No** — published 2026-04-27, `retracted=false` |
| `setup-dart` / `PUB_TOKEN` alone | **No** — the successful v0.9.1 publish had both, same `PUB_CACHE` |
| setup-dart ↔ Flutter Dart-version drift | **No** — v0.9.1 succeeded *mismatched* (3.13.2 vs 3.13.1); today fails *matched* (3.13.3 vs 3.13.3) |
| Cold Flutter SDK / no cache | **No** — `ci.yml` resolves this commit on Flutter 3.47.3 with caching skipped |

| Flutter | setup-dart | Cold | `flutter pub get` |
|---|---|---|---|
| 3.47.1 | yes | yes | ✅ v0.9.1 publish |
| 3.47.3 | no | yes | ✅ ci.yml, today |
| 3.47.3 | **yes** | yes | ❌ ×3 |

Failure requires Flutter 3.47.3 **and** `setup-dart` together. I could not establish the mechanism, so this does not claim a root cause — it pins the one configuration with direct evidence of publishing this repo successfully.

## Scope

`ci.yml` intentionally keeps floating on `stable`, so genuine Flutter regressions still surface on PRs. Only the irreversible publish path is pinned — where determinism is arguably correct regardless.

Follow-up worth filing: identify the 3.47.3 ↔ setup-dart interaction and unpin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)