### PR TITLE
ci: unpin the publish SDKs, add a publish concurrency guard

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,13 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 
+# A tag re-push starts a second run for the same tag, and pub.dev versions are
+# immutable, so two concurrent publishes would race to upload the same version.
+# Queue instead of cancelling: never interrupt a run that may be mid-publish.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
 # Needed for dart pub publish with OIDC authentication
 permissions:
   id-token: write
@@ -15,39 +22,10 @@ jobs:
     environment: pub.dev
     steps:
       - uses: actions/checkout@v4
-      # BOTH SDKs are pinned, unlike ci.yml which floats on `stable`.
-      #
-      # setup-dart is required here — it supplies the PUB_TOKEN that
-      # `dart pub publish` uses for pub.dev OIDC, so it cannot simply be
-      # dropped. But the standalone Dart it puts on PATH takes part in
-      # `flutter pub get`, and Dart 3.13.3 breaks that resolution:
-      #
-      #   Because flutter_tools depends on test 1.31.1 which doesn't match any
-      #   versions, version solving failed.
-      #
-      # Every observation fits "standalone Dart 3.13.3 on PATH breaks it",
-      # and nothing else does:
-      #
-      #   Flutter 3.47.1 + standalone 3.13.2         -> published v0.9.1
-      #   Flutter 3.47.1 + standalone 3.13.3         -> fails
-      #   Flutter 3.47.3 + standalone 3.13.3         -> fails (x3)
-      #   Flutter 3.47.3, no standalone Dart (ci.yml)-> resolves fine
-      #
-      # Note the last row: Flutter's *bundled* 3.13.3 is fine. It is the
-      # standalone SDK that is the problem, not the version in the abstract,
-      # which is why matching setup-dart to Flutter's bundled Dart is not the
-      # fix either. This pins the exact pair proven to publish this repo.
-      #
-      # Publishing is irreversible, so determinism here is a feature. Revisit
-      # when a later Dart resolves cleanly next to flutter pub get; verify on a
-      # throwaway tag before bumping either pin.
       - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: 3.13.2
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
-          flutter-version: 3.47.1
 
       # Both packages publish in lockstep — verify the tag matches *both*
       # pubspecs before doing anything destructive.


### PR DESCRIPTION
Reverts #38 and #39, which fixed nothing and made the situation worse, and adds a concurrency guard.

## What actually happened

A matrix probe on `diag/pub-resolution` ran four configurations that only resolve dependencies, never publish:

| Variant | Config | `flutter pub get` |
|---|---|---|
| A | `flutter-action` alone (= `ci.yml`) | ✅ |
| **B** | **`setup-dart` → `flutter-action` (= `publish.yml`)** | **✅** |
| C | same as B, `PUB_TOKEN` cleared | ✅ |
| D | `setup-dart` after resolution | ✅ |

**B is `publish.yml`'s exact configuration** — standalone Dart 3.13.3 installed, `PUB_TOKEN` set, cold SDK — and it passed, while that same configuration had failed three times an hour earlier. The original failure was **transient pub.dev state**.

## Why the pins had to go

Pinning Flutter to 3.47.1 froze the publish path onto a `flutter_tools` whose `test 1.31.1` pin no longer resolves against today's index, so the job kept failing *after* the transient problem cleared:

| Run | Flutter | Cold | Result |
|---|---|---|---|
| Diagnostic B | 3.47.3 (floating) | yes | ✅ |
| Publish w/ #38+#39 | 3.47.1 (pinned) | yes | ❌ |

The setup block is restored byte-identical to pre-#38.

## Also worth recording

Two of my theories were mechanically impossible, and one log line disproves both: `which dart` resolves to Flutter's **bundled** dart in every variant, so the standalone SDK `setup-dart` installs never participates in resolution.

## Concurrency guard

Unrelated but real — re-pushing the tag during debugging started two publish runs for the same tag, racing to upload an immutable version. `cancel-in-progress: false` queues rather than cancels, so a run that may be mid-publish is never interrupted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)