### PR TITLE
feat: expose native video frame consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Add vendor-neutral native video-frame consumer registries on iOS and Android
+  for sibling plugins that need sustained processing without Dart byte copies.
+
 ## 0.9.2
 
 **BREAKING CHANGES** — note these ship in a *patch* release. A constraint of

--- a/README.md
+++ b/README.md
@@ -632,6 +632,16 @@ Frame bytes are codec-dependent:
 
 Subscribing to `videoFramesStream()` is zero-cost when there are no listeners — the plugin won't encode or emit anything until the first subscriber attaches. Always subscribe *before* calling `startStreamSession()` if you want to capture the opening keyframe.
 
+**Native frame consumers.** Sibling native plugins that need sustained raw-frame
+processing can register directly with
+`MetaWearablesDatNativeVideoFrameConsumers` on iOS or
+`NativeVideoFrameConsumers` on Android. The synchronous callback receives the
+original `CMSampleBuffer` (iOS) or a read-only I420 buffer view (Android), so
+pixels do not cross a Flutter platform channel. Consumers must unregister on
+shutdown and must not retain the supplied buffer after the callback returns.
+Only `VideoCodec.raw` sessions are dispatched through this native extension
+point.
+
 **Notes and limitations:**
 
 - **On-device muxing.** The plugin gives you raw frame bytes — muxing into mp4/mov is the host app's responsibility. For hvc1 on iOS this is usually a one-liner with `ffmpeg_kit_flutter`; for raw you'll want to transcode first.

--- a/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
+++ b/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/MetaWearablesDatPlugin.kt
@@ -1320,6 +1320,7 @@ class MetaWearablesDatPlugin :
                 videoJob =
                         scope.launch(Dispatchers.Default) {
                             newStream.videoStream.collect { videoFrame ->
+                                NativeVideoFrameConsumers.dispatch(videoFrame)
                                 if (frameProcessor.needsBufferSizeUpdate(
                                                 videoFrame.width,
                                                 videoFrame.height,

--- a/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/NativeVideoFrameConsumer.kt
+++ b/android/src/main/kotlin/io/rodcone/flutter_meta_wearables_dat/NativeVideoFrameConsumer.kt
@@ -1,0 +1,56 @@
+package io.rodcone.flutter_meta_wearables_dat
+
+import java.nio.ByteBuffer
+import java.util.concurrent.CopyOnWriteArraySet
+
+/**
+ * A synchronous, native-only view of a DAT video frame.
+ *
+ * Consumers must finish reading [buffer] before [onVideoFrame] returns. The
+ * buffer is a read-only duplicate whose position is independent from DAT's
+ * source buffer, but its backing memory is owned by the DAT SDK and may be
+ * reused after the callback.
+ */
+public data class NativeVideoFrame(
+        val buffer: ByteBuffer,
+        val width: Int,
+        val height: Int,
+        val presentationTimeUs: Long,
+        val isCompressed: Boolean,
+)
+
+/** Receives frames without routing their bytes through a Flutter event channel. */
+public fun interface NativeVideoFrameConsumer {
+    public fun onVideoFrame(frame: NativeVideoFrame)
+}
+
+/**
+ * Process-local registry for optional native encoders, recorders, and vision
+ * processors hosted by sibling Flutter plugins.
+ */
+public object NativeVideoFrameConsumers {
+    private val consumers = CopyOnWriteArraySet<NativeVideoFrameConsumer>()
+
+    @JvmStatic
+    public fun add(consumer: NativeVideoFrameConsumer) {
+        consumers.add(consumer)
+    }
+
+    @JvmStatic
+    public fun remove(consumer: NativeVideoFrameConsumer) {
+        consumers.remove(consumer)
+    }
+
+    internal fun dispatch(frame: com.meta.wearable.dat.camera.types.VideoFrame) {
+        if (consumers.isEmpty()) return
+        val nativeFrame =
+                NativeVideoFrame(
+                        buffer = frame.buffer.asReadOnlyBuffer(),
+                        width = frame.width,
+                        height = frame.height,
+                        presentationTimeUs = frame.presentationTimeUs,
+                        isCompressed = frame.isCompressed,
+                )
+        consumers.forEach { consumer -> consumer.onVideoFrame(nativeFrame) }
+    }
+}

--- a/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/MetaWearablesDatPlugin.swift
+++ b/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/MetaWearablesDatPlugin.swift
@@ -1223,6 +1223,10 @@ public class MetaWearablesDatPlugin: NSObject, FlutterPlugin {
       return
     }
 
+    if currentVideoCodec == .raw {
+      MetaWearablesDatNativeVideoFrameConsumers.dispatch(videoFrame.sampleBuffer)
+    }
+
     let pts = CMSampleBufferGetPresentationTimeStamp(videoFrame.sampleBuffer)
     let ptsUs: Int64 = pts.isValid ? Int64(CMTimeGetSeconds(pts) * 1_000_000) : 0
 

--- a/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/NativeVideoFrameConsumer.swift
+++ b/ios/flutter_meta_wearables_dat/Sources/flutter_meta_wearables_dat/NativeVideoFrameConsumer.swift
@@ -1,0 +1,37 @@
+import AVFoundation
+import Foundation
+
+/// Receives raw DAT frames without copying their pixels through Flutter.
+///
+/// Consumers must not retain the sample buffer after this callback returns.
+public protocol MetaWearablesDatNativeVideoFrameConsumer: AnyObject {
+  func metaWearablesDatDidOutput(sampleBuffer: CMSampleBuffer)
+}
+
+/// Process-local registry used by optional sibling Flutter plugins.
+public final class MetaWearablesDatNativeVideoFrameConsumers: NSObject {
+  private static let lock = NSLock()
+  private static let consumers = NSHashTable<AnyObject>.weakObjects()
+
+  public static func add(_ consumer: MetaWearablesDatNativeVideoFrameConsumer) {
+    lock.lock()
+    consumers.add(consumer)
+    lock.unlock()
+  }
+
+  public static func remove(_ consumer: MetaWearablesDatNativeVideoFrameConsumer) {
+    lock.lock()
+    consumers.remove(consumer)
+    lock.unlock()
+  }
+
+  static func dispatch(_ sampleBuffer: CMSampleBuffer) {
+    lock.lock()
+    let snapshot = consumers.allObjects
+    lock.unlock()
+    snapshot.forEach {
+      ($0 as? MetaWearablesDatNativeVideoFrameConsumer)?
+        .metaWearablesDatDidOutput(sampleBuffer: sampleBuffer)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- expose process-local native video-frame consumer registries on iOS and Android
- preserve the existing Dart event stream and Flutter texture behavior
- document synchronous ownership so consumers cannot retain DAT-owned buffers

This is a vendor-neutral extension point for optional native encoders, recorders,
and vision processors. It contains no Rodcone platform or AWS-specific code.

## Validation

- `flutter analyze`
- `flutter test`
- native build validation in repository CI
